### PR TITLE
fix: Crash on updating KubeConfig from disk

### DIFF
--- a/src/KubeUI/Client/ClusterManager.cs
+++ b/src/KubeUI/Client/ClusterManager.cs
@@ -102,7 +102,17 @@ public sealed partial class ClusterManager : ObservableObject, IDisposable
 
     private void Watcher_Changed(object sender, FileSystemEventArgs e)
     {
-        Dispatcher.UIThread.Post(() => LoadFromConfigFromPath(e.FullPath), DispatcherPriority.Background);
+        Dispatcher.UIThread.Post(() =>
+        {
+            try
+            {
+                LoadFromConfigFromPath(e.FullPath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error Watching Kube Config {0}", e.FullPath);
+            }
+        }, DispatcherPriority.Background);
     }
 
     private void LoadClusters()


### PR DESCRIPTION
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at k8s.KubernetesClientConfiguration.LoadKubeConfigAsync(FileInfo kubeconfig, Boolean useRelativePaths)
   at k8s.KubernetesClientConfiguration.LoadKubeConfigAsync(String kubeconfigPath, Boolean useRelativePaths)
   at k8s.KubernetesClientConfiguration.LoadKubeConfig(String kubeconfigPath, Boolean useRelativePaths)
   at KubeUI.Client.ClusterManager.LoadFromConfigFromPath(String path)
   at KubeUI.Client.ClusterManager.<>c__DisplayClass12_0.<Watcher_Changed>b__0()
   at Avalonia.Threading.DispatcherOperation.InvokeCore()
   at Avalonia.Threading.DispatcherOperation.Execute()
   at Avalonia.Threading.Dispatcher.ExecuteJob(DispatcherOperation job)
   at Avalonia.Threading.Dispatcher.ExecuteJobsCore(Boolean fromExplicitBackgroundProcessingCallback)
   at Avalonia.Threading.Dispatcher.Signaled()
   at Avalonia.X11.X11PlatformThreading.CheckSignaled()
   at Avalonia.X11.X11PlatformThreading.RunLoop(CancellationToken cancellationToken)
   at Avalonia.Threading.DispatcherFrame.Run(IControlledDispatcherImpl impl)
   at Avalonia.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken)
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.StartCore(String[] args)
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args)
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder builder, String[] args, Action`1 lifetimeBuilder)
   at KubeUI.Desktop.Program.Main(String[] args)

```