### PR TITLE
chore: fix minor spelling errors in comments and UI column

### DIFF
--- a/src/KubeUI/Client/Informer/IResourceInformer.cs
+++ b/src/KubeUI/Client/Informer/IResourceInformer.cs
@@ -28,7 +28,7 @@ public interface IResourceInformer<TResource> : IResourceInformer where TResourc
 {
     /// <summary>
     /// Registers a callback for change notification. To ensure no events are missed the registration
-    /// may be created in the constructor of a dependant <see cref="IHostedService"/>. The returned
+    /// may be created in the constructor of a dependent <see cref="IHostedService"/>. The returned
     /// registration should be disposed when the receiver is ending its work.
     /// </summary>
     /// <param name="callback">The delegate that is invoked with each resource notification.</param>
@@ -49,7 +49,7 @@ public interface IResourceInformer
 
     /// <summary>
     /// Registers a callback for change notification. To ensure no events are missed the registration
-    /// may be created in the constructor of a dependant <see cref="IHostedService"/>. The returned
+    /// may be created in the constructor of a dependent <see cref="IHostedService"/>. The returned
     /// registration should be disposed when the receiver is ending its work.
     /// </summary>
     /// <param name="callback">The delegate that is invoked with each resource notification.</param>

--- a/src/KubeUI/Resources/Configuration/V1PodDisruptionBudgetConfig.cs
+++ b/src/KubeUI/Resources/Configuration/V1PodDisruptionBudgetConfig.cs
@@ -14,7 +14,7 @@ public sealed partial class V1PodDisruptionBudgetConfig : ResourceConfigBase<V1P
             NamespaceColumn(),
             new ResourceListColumn<V1PodDisruptionBudget, IntstrIntOrString>()
             {
-                Name = "Min Avalilable",
+                Name = "Min Available",
                 Display = x => x.Spec.MinAvailable != null ? x.Spec.MinAvailable.Value : "",
                 Field = x => x.Spec.MinAvailable,
                 Width = nameof(DataGridLengthUnitType.SizeToHeader)


### PR DESCRIPTION
## Summary
- fix `Min Avalilable` column header typo
- correct `dependant` to `dependent` in `IResourceInformer` comments

## Testing
- `dotnet test --no-build` *(fails: argument invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68407d886f988326b6f8621a29d8feb2