### PR TITLE
fix: async informer startup and UI thread simplification

### DIFF
--- a/src/KubeUI/Client/Cluster.cs
+++ b/src/KubeUI/Client/Cluster.cs
@@ -399,9 +399,12 @@ public sealed partial class Cluster : ObservableObject, ICluster
             {
                 var informer = new ResourceInformer<T>(Client, _serviceProvider.GetRequiredService<IHostApplicationLifetime>(), _loggerFactory.CreateLogger<ResourceInformer<T>>());
                 container.Informers.Add(informer);
-                informer.Register(GetResourceInformerCallback<T>());
-                informer.StartWatching();
-                _ = informer.RunInfinite(CancellationToken.None);
+                _ = Task.Run(() =>
+                {
+                    informer.Register(GetResourceInformerCallback<T>());
+                    informer.StartWatching();
+                    _ = informer.RunInfinite(CancellationToken.None);
+                });
             }
             else
             {
@@ -418,9 +421,13 @@ public sealed partial class Cluster : ObservableObject, ICluster
                     {
                         var informer = new ResourceInformer<T>(Client, _serviceProvider.GetRequiredService<IHostApplicationLifetime>(), _loggerFactory.CreateLogger<ResourceInformer<T>>(), @namespace: ns);
                         container.Informers.Add(informer);
-                        informer.Register(GetResourceInformerCallback<T>());
-                        informer.StartWatching();
-                        _ = informer.RunInfinite(CancellationToken.None);
+
+                        _ = Task.Run(() =>
+                        {
+                            informer.Register(GetResourceInformerCallback<T>());
+                            informer.StartWatching();
+                            _ = informer.RunInfinite(CancellationToken.None);
+                        });
                     }
                 }
             }

--- a/src/KubeUI/ViewModels/NavigationViewModel.cs
+++ b/src/KubeUI/ViewModels/NavigationViewModel.cs
@@ -34,11 +34,11 @@ public sealed partial class NavigationViewModel : ViewModelBase
         }
         else if (item is ResourceNavigationLink resourceNavLink)
         {
-            _ = Task.Run(() => SelectResourceNavigationLink(resourceNavLink));
+            SelectResourceNavigationLink(resourceNavLink);
         }
         else if (item is NavigationLink navLink)
         {
-            _ = Task.Run(async () => await SelectNavigationLink(navLink));
+            _ = SelectNavigationLink(navLink);
         }
 
         if (item is NavigationItem nav && nav.NavigationItems.Count > 0)
@@ -60,7 +60,7 @@ public sealed partial class NavigationViewModel : ViewModelBase
 
         nav.Count ??= nav.Cluster.GetResourceCount(nav.ControlType);
 
-        Dispatcher.UIThread.Post(() => Factory.AddToDocuments(vm));
+        Factory.AddToDocuments(vm);
     }
 
     private async Task SelectNavigationLink(NavigationLink link)
@@ -118,7 +118,7 @@ public sealed partial class NavigationViewModel : ViewModelBase
                 init.Initialize(link.Cluster);
             }
 
-            Dispatcher.UIThread.Post(() => Factory.AddToDocuments(vm));
+            Factory.AddToDocuments(vm);
         }
     }
 }

--- a/src/KubeUI/ViewModels/NavigationViewModel.cs
+++ b/src/KubeUI/ViewModels/NavigationViewModel.cs
@@ -25,7 +25,7 @@ public sealed partial class NavigationViewModel : ViewModelBase
         //_notificationManager = Application.Current.GetRequiredService<INotificationManager>();
     }
 
-    public void TreeView_SelectionChanged(object? item)
+    public async void TreeView_SelectionChanged(object? item)
     {
         if (item is Cluster cluster)
         {
@@ -38,7 +38,7 @@ public sealed partial class NavigationViewModel : ViewModelBase
         }
         else if (item is NavigationLink navLink)
         {
-            _ = SelectNavigationLink(navLink);
+            await SelectNavigationLink(navLink);
         }
 
         if (item is NavigationItem nav && nav.NavigationItems.Count > 0)


### PR DESCRIPTION
Refactored Cluster to start resource informers asynchronously using Task.Run, preventing main thread blocking. In NavigationViewModel, removed Task.Run for navigation link selection and now call Factory.AddToDocuments directly instead of posting to the UI thread dispatcher, simplifying code and improving responsiveness.