### PR TITLE
fix: crash on Resource selection

### DIFF
--- a/src/KubeUI/DockFactory.cs
+++ b/src/KubeUI/DockFactory.cs
@@ -223,7 +223,8 @@ public static class FactoryExtensions
             return false;
         }
 
-        factory.AddDockable(documents, vm);
+        var insertIndex = documents.VisibleDockables?.Count ?? 0;
+        factory.InsertDockable(documents, vm, insertIndex);
         factory.SetActiveDockable(vm);
         factory.SetFocusedDockable(documents, vm);
 
@@ -244,7 +245,8 @@ public static class FactoryExtensions
             return false;
         }
 
-        factory.AddDockable(bottomToolsDock, vm);
+        var insertIndex = bottomToolsDock.VisibleDockables?.Count ?? 0;
+        factory.InsertDockable(bottomToolsDock, vm, insertIndex);
         factory.SetActiveDockable(vm);
         factory.SetFocusedDockable(bottomToolsDock, vm);
 


### PR DESCRIPTION
### Motivation
- Ensure dockables are appended to the end of the target docks using an explicit insertion index rather than relying on `AddDockable`, to preserve predictable ordering and visibility behavior.

### Description
- Replace calls to `AddDockable(documents, vm)` and `AddDockable(bottomToolsDock, vm)` with `InsertDockable(..., insertIndex)` where `insertIndex` is `VisibleDockables?.Count ?? 0` so the item is appended.

### Testing
- Ran `dotnet build` and `dotnet test`, both completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fbf8953488326ac9639ab7f56037e)