### PR TITLE
fix(Cluster): update resource invalidation logic to clear cached seed tasks

### DIFF
--- a/src/KubeUI.Avalonia/Shell/Navigation/ViewModels/NavigationViewModel.cs
+++ b/src/KubeUI.Avalonia/Shell/Navigation/ViewModels/NavigationViewModel.cs
@@ -751,6 +751,9 @@ public sealed partial class NavigationViewModel : ViewModelBase, IDisposable
             return;
         }
 
+        var addedConfigList = addedConfigs as IReadOnlyList<PendingCustomResourceConfig> ?? addedConfigs.ToList();
+        ReloadOpenCustomResourceDocuments(cluster, addedConfigList);
+
         var root = GetOrCreateCustomResourceDefinitionsRoot(node, cluster);
         if (root == null)
         {
@@ -762,7 +765,7 @@ public sealed partial class NavigationViewModel : ViewModelBase, IDisposable
             RemoveCustomResourceDefinition(root, cluster, removedKind);
         }
 
-        foreach (var addedConfig in addedConfigs)
+        foreach (var addedConfig in addedConfigList)
         {
             ApplyCustomResourceNavigationUpdate(node, cluster, addedConfig.ResourceConfig, isVisible: true);
         }
@@ -1408,32 +1411,33 @@ public sealed partial class NavigationViewModel : ViewModelBase, IDisposable
 
     private void OpenResourceNavigation(ResourceNavigationLink nav, bool forceNewTab = false)
     {
-        if (nav.ControlType == null)
+        var currentResourceConfig = ResolveCurrentResourceConfig(nav);
+        if (currentResourceConfig == null)
         {
             _logger.LogError("Unable to resolve resource navigation target for {Name}", nav.Name);
             return;
         }
 
-        var expectedId = $"{nav.Cluster.Name}-{GroupApiVersionKind.From(nav.ControlType)}";
+        var expectedId = $"{nav.Cluster.Name}-{currentResourceConfig.Kind}";
 
-        if (!forceNewTab && FindExistingResourceDocument(nav) is IDockable existingDocument)
+        if (!forceNewTab && FindExistingResourceDocument(nav.Cluster, currentResourceConfig.Kind) is IDockable existingDocument)
         {
+            if (existingDocument is IResourceListViewModel existingResourceList
+                && existingResourceList.ResourceConfig.Type != currentResourceConfig.Type)
+            {
+                existingDocument = ReplaceResourceDocument(existingResourceList, currentResourceConfig.Type) ?? existingDocument;
+            }
+
             ActivateDocument(existingDocument);
             return;
         }
 
-        var resourceListType = typeof(ResourceListViewModel<>).MakeGenericType(nav.ControlType);
-        var vm = _serviceProvider.GetRequiredService(resourceListType) as IDockable;
+        var vm = CreateResourceDocument(nav.Cluster, currentResourceConfig.Type);
 
         if (vm == null)
         {
             _logger.LogError("Unable to resolve resource list view model for {Name}", nav.Name);
             return;
-        }
-
-        if (vm is IInitializeCluster init)
-        {
-            init.Initialize(nav.Cluster);
         }
 
         if (forceNewTab)
@@ -1553,13 +1557,113 @@ public sealed partial class NavigationViewModel : ViewModelBase, IDisposable
         Factory.SetFocusedDockable(documents, dockable);
     }
 
-    private IDockable? FindExistingResourceDocument(ResourceNavigationLink nav)
+    private IResourceConfig? ResolveCurrentResourceConfig(ResourceNavigationLink nav)
     {
         if (nav.ControlType == null)
         {
             return null;
         }
 
+        var kind = GroupApiVersionKind.From(nav.ControlType);
+        return nav.Cluster.GetResourceConfigs().FirstOrDefault(config => config.Kind == kind);
+    }
+
+    private IDockable? CreateResourceDocument(ClusterWorkspaceViewModel cluster, Type resourceType)
+    {
+        var resourceListType = typeof(ResourceListViewModel<>).MakeGenericType(resourceType);
+        if (_serviceProvider.GetRequiredService(resourceListType) is not IDockable vm)
+        {
+            return null;
+        }
+
+        if (vm is IInitializeCluster init)
+        {
+            init.Initialize(cluster);
+        }
+
+        return vm;
+    }
+
+    private void ReloadOpenCustomResourceDocuments(ClusterWorkspaceViewModel cluster, IReadOnlyList<PendingCustomResourceConfig> addedConfigs)
+    {
+        var documents = Factory.GetDockable<IDocumentDock>("Documents");
+        var visibleDockables = documents?.VisibleDockables;
+        if (visibleDockables == null || visibleDockables.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var addedConfig in addedConfigs)
+        {
+            var staleDocuments = visibleDockables
+                .OfType<IResourceListViewModel>()
+                .Where(resourceList =>
+                    ReferenceEquals(resourceList.Cluster, cluster)
+                    && resourceList.Kind == addedConfig.Kind
+                    && resourceList.ResourceConfig.Type != addedConfig.ResourceConfig.Type)
+                .Cast<IDockable>()
+                .ToList();
+
+            foreach (var staleDocument in staleDocuments)
+            {
+                if (staleDocument is IResourceListViewModel staleResourceList)
+                {
+                    ReplaceResourceDocument(staleResourceList, addedConfig.ResourceConfig.Type);
+                }
+            }
+        }
+    }
+
+    private IDockable? ReplaceResourceDocument(IResourceListViewModel existingResourceList, Type resourceType)
+    {
+        if (existingResourceList is not IDockable existingDockable)
+        {
+            return null;
+        }
+
+        var documents = Factory.GetDockable<IDocumentDock>("Documents");
+        var visibleDockables = documents?.VisibleDockables;
+        if (documents == null || visibleDockables == null)
+        {
+            return null;
+        }
+
+        var replacement = CreateResourceDocument(existingResourceList.Cluster, resourceType);
+        if (replacement is not IResourceListViewModel replacementResourceList)
+        {
+            return null;
+        }
+
+        replacement.Id = existingDockable.Id;
+        replacementResourceList.IsNamespaceSelectionLinked = existingResourceList.IsNamespaceSelectionLinked;
+        replacementResourceList.SearchQuery = existingResourceList.SearchQuery;
+
+        if (!replacementResourceList.IsNamespaceSelectionLinked)
+        {
+            replacementResourceList.SelectedNamespaces.Clear();
+            foreach (var selectedNamespace in existingResourceList.SelectedNamespaces)
+            {
+                replacementResourceList.SelectedNamespaces.Add(selectedNamespace);
+            }
+        }
+
+        var insertIndex = visibleDockables.IndexOf(existingDockable);
+        var wasActive = ReferenceEquals(documents.ActiveDockable, existingDockable);
+
+        Factory.CloseDockable(existingDockable);
+        Factory.InsertDockable(documents, replacement, Math.Max(0, Math.Min(insertIndex, documents.VisibleDockables?.Count ?? 0)));
+
+        if (wasActive)
+        {
+            Factory.SetActiveDockable(replacement);
+            Factory.SetFocusedDockable(documents, replacement);
+        }
+
+        return replacement;
+    }
+
+    private IDockable? FindExistingResourceDocument(ClusterWorkspaceViewModel cluster, GroupApiVersionKind kind)
+    {
         var documents = Factory.GetDockable<IDocumentDock>("Documents");
         if (documents?.VisibleDockables == null)
         {
@@ -1569,8 +1673,8 @@ public sealed partial class NavigationViewModel : ViewModelBase, IDisposable
         return documents.VisibleDockables
             .OfType<IResourceListViewModel>()
             .FirstOrDefault(resourceList =>
-                ReferenceEquals(resourceList.Cluster, nav.Cluster)
-                && resourceList.ResourceConfig.Type == nav.ControlType) as IDockable;
+                ReferenceEquals(resourceList.Cluster, cluster)
+                && resourceList.Kind == kind) as IDockable;
     }
 
     private string CreateUniqueDockableId(string baseId)
@@ -1633,4 +1737,3 @@ internal sealed class PendingClusterNavigationUpdate
         }
     }
 }
-

--- a/src/KubeUI.Kubernetes/Client/Cluster.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.cs
@@ -522,14 +522,14 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime
         var removedType = ModelCache.RemoveCustomResourceDefinition(crd);
         if (removedType != null)
         {
-            RemoveSeededResourceContainer(removedType);
+            InvalidateSeededResource(removedType);
         }
     }
 
     private async Task ReplaceCustomResourceDefinitionArtifactsAsync(Type? previousType, Type currentType)
     {
-        var hadExistingContainer = previousType != null && RemoveSeededResourceContainer(previousType);
-        if (!hadExistingContainer)
+        var invalidatedSeedState = previousType != null && InvalidateSeededResource(previousType);
+        if (!invalidatedSeedState)
         {
             return;
         }
@@ -537,20 +537,21 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime
         await SeedResourceAsync(currentType).ConfigureAwait(false);
     }
 
-    private bool RemoveSeededResourceContainer(Type resourceType)
+    private bool InvalidateSeededResource(Type resourceType)
     {
         var kind = GroupApiVersionKind.From(resourceType);
+        var removedSeedTask = _seedTasks.TryRemove(kind, out _);
+
         if (!Objects.TryRemove(kind, out var existingContainer))
         {
-            return false;
+            return removedSeedTask;
         }
 
-        if (existingContainer is not IClearableResourceContainer resourceContainer)
+        if (existingContainer is IClearableResourceContainer resourceContainer)
         {
-            return false;
+            ClearResourceContainer(resourceContainer);
         }
 
-        ClearResourceContainer(resourceContainer);
         return true;
     }
 

--- a/tests/KubeUI.Avalonia.Tests/Shell/Navigation/NavigationViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Shell/Navigation/NavigationViewModelTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
@@ -16,10 +17,12 @@ using FluentAvalonia.UI.Controls;
 using k8s;
 using k8s.Models;
 using KubernetesClient.Informer.Client;
+using KubeUI.Avalonia.Features.Resources.List.ViewModels;
 using KubeUI.Avalonia.Resources;
 using KubeUI.Avalonia.Tests.Features.Clusters.Workspace;
 using KubeUI.Avalonia.Tests.Infra;
 using KubeUI.Kubernetes;
+using KubeUI.Testing;
 using Moq;
 using Shouldly;
 
@@ -166,6 +169,35 @@ public class NavigationViewModelTests : AvaloniaTestBase
         }
 
         return null;
+    }
+
+    private static Type? GetCustomResourceType(TestClusterRuntime runtime, V1CustomResourceDefinition crd)
+    {
+        var version = crd.Spec?.Versions?.FirstOrDefault(x => x.Served && x.Storage)?.Name;
+        return version == null ? null : runtime.ModelCache.GetResourceType(crd.Spec.Group, version, crd.Spec.Names.Kind);
+    }
+
+    private static async Task AddGeneratedCustomResourceAsync(ClusterWorkspaceViewModel cluster, Type resourceType, V1CustomResourceDefinition crd, string @namespace, string name)
+    {
+        var resource = Activator.CreateInstance(resourceType).ShouldNotBeNull();
+        var metadata = new V1ObjectMeta
+        {
+            NamespaceProperty = @namespace,
+            Name = name,
+            CreationTimestamp = DateTime.UtcNow,
+        };
+
+        resourceType.GetProperty(nameof(IKubernetesObject<V1ObjectMeta>.Metadata))?.SetValue(resource, metadata);
+        resourceType.GetProperty(nameof(IKubernetesObject.ApiVersion))?.SetValue(resource, $"{crd.Spec.Group}/{crd.Spec.Versions.First(x => x.Served && x.Storage).Name}");
+        resourceType.GetProperty(nameof(IKubernetesObject.Kind))?.SetValue(resource, crd.Spec.Names.Kind);
+
+        var addOrUpdateMethod = typeof(ClusterWorkspaceViewModel)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .First(x => x.Name == nameof(ClusterWorkspaceViewModel.AddOrUpdateResource) && x.IsGenericMethodDefinition && x.GetParameters().Length == 1)
+            .MakeGenericMethod(resourceType);
+
+        await (Task)addOrUpdateMethod.Invoke(cluster, [resource])!;
+        Dispatcher.UIThread.RunJobs();
     }
 
     [AvaloniaFact]
@@ -1427,6 +1459,132 @@ public class NavigationViewModelTests : AvaloniaTestBase
 
         rebuiltResourceLink.ShouldNotBeNull();
         (rebuiltResourceLink.Count is not null).ShouldBeTrue();
+    }
+
+    [AvaloniaFact]
+    public async Task updated_crd_reloads_open_resource_list_document_to_the_new_generated_type()
+    {
+        var runtime = new TestCluster
+        {
+            Connected = true,
+            Status = ClusterStatus.Connected,
+        };
+
+        var workspace = CreateWorkspace(runtime);
+        await workspace.EnsureWorkspaceStateInitializedAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var originalCrd = ClusterWorkspaceTestCustomResourceDefinitionFactory.Create("tests.kubeui.com", "tests", "someString");
+        await runtime.AddOrUpdateResource(originalCrd);
+
+        var originalType = await WaitForValueAsync(() => GetCustomResourceType(runtime, originalCrd));
+        originalType.ShouldNotBeNull();
+        await AddGeneratedCustomResourceAsync(workspace, originalType, originalCrd, "default", "old-item");
+
+        var vm = CreateViewModel();
+        vm.ClusterCatalog.Clusters.Add(workspace);
+        Dispatcher.UIThread.RunJobs();
+
+        var clusterNode = vm.Clusters.Single(x => x.Cluster == workspace);
+        var originalLink = await WaitForValueAsync(() => FindResourceLink(clusterNode, "Tests"));
+        originalLink.ShouldNotBeNull();
+
+        await vm.OpenResourceNavigationCommand.ExecuteAsync(originalLink);
+        Dispatcher.UIThread.RunJobs();
+
+        var documents = vm.Factory.GetDockable<IDocumentDock>("Documents");
+        documents.ShouldNotBeNull();
+
+        await WaitForAsync(() =>
+            documents.VisibleDockables?.OfType<IResourceListViewModel>().Any(x => ReferenceEquals(x.Cluster, workspace) && x.Kind == GroupApiVersionKind.From(originalType)) == true);
+
+        var originalDocument = documents.VisibleDockables!
+            .OfType<IResourceListViewModel>()
+            .Single(x => ReferenceEquals(x.Cluster, workspace) && x.Kind == GroupApiVersionKind.From(originalType));
+
+        var updatedCrd = ClusterWorkspaceTestCustomResourceDefinitionFactory.Create("tests.kubeui.com", "tests", "otherString");
+        await runtime.AddOrUpdateResource(updatedCrd);
+
+        var updatedType = await WaitForValueAsync(() => GetCustomResourceType(runtime, updatedCrd));
+        updatedType.ShouldNotBeNull();
+        updatedType.ShouldNotBe(originalType);
+        await AddGeneratedCustomResourceAsync(workspace, updatedType, updatedCrd, "default", "new-item");
+
+        await WaitForAsync(() =>
+            documents.VisibleDockables?.OfType<IResourceListViewModel>().Any(x =>
+                ReferenceEquals(x.Cluster, workspace)
+                && x.Kind == GroupApiVersionKind.From(updatedType)
+                && x.ResourceConfig.Type == updatedType
+                && x.ItemCount == 1) == true);
+
+        documents.VisibleDockables!
+            .OfType<IResourceListViewModel>()
+            .Any(x => ReferenceEquals(x, originalDocument))
+            .ShouldBeFalse();
+
+        var reloadedDocument = documents.VisibleDockables!
+            .OfType<IResourceListViewModel>()
+            .Single(x => ReferenceEquals(x.Cluster, workspace) && x.Kind == GroupApiVersionKind.From(updatedType));
+
+        reloadedDocument.ResourceConfig.Type.ShouldBe(updatedType);
+        reloadedDocument.ItemCount.ShouldBe(1);
+    }
+
+    [AvaloniaFact]
+    public async Task stale_crd_navigation_link_opens_the_current_generated_resource_type()
+    {
+        var runtime = new TestCluster
+        {
+            Connected = true,
+            Status = ClusterStatus.Connected,
+        };
+
+        var workspace = CreateWorkspace(runtime);
+        await workspace.EnsureWorkspaceStateInitializedAsync();
+        Dispatcher.UIThread.RunJobs();
+
+        var originalCrd = ClusterWorkspaceTestCustomResourceDefinitionFactory.Create("tests.kubeui.com", "tests", "someString");
+        await runtime.AddOrUpdateResource(originalCrd);
+
+        var originalType = await WaitForValueAsync(() => GetCustomResourceType(runtime, originalCrd));
+        originalType.ShouldNotBeNull();
+
+        var vm = CreateViewModel();
+        vm.ClusterCatalog.Clusters.Add(workspace);
+        Dispatcher.UIThread.RunJobs();
+
+        var clusterNode = vm.Clusters.Single(x => x.Cluster == workspace);
+        var staleLink = await WaitForValueAsync(() => FindResourceLink(clusterNode, "Tests"));
+        staleLink.ShouldNotBeNull();
+        staleLink.ControlType.ShouldBe(originalType);
+
+        var updatedCrd = ClusterWorkspaceTestCustomResourceDefinitionFactory.Create("tests.kubeui.com", "tests", "otherString");
+        await runtime.AddOrUpdateResource(updatedCrd);
+
+        var updatedType = await WaitForValueAsync(() => GetCustomResourceType(runtime, updatedCrd));
+        updatedType.ShouldNotBeNull();
+        updatedType.ShouldNotBe(originalType);
+        await AddGeneratedCustomResourceAsync(workspace, updatedType, updatedCrd, "default", "new-item");
+
+        await vm.OpenResourceNavigationCommand.ExecuteAsync(staleLink);
+        Dispatcher.UIThread.RunJobs();
+
+        var documents = vm.Factory.GetDockable<IDocumentDock>("Documents");
+        documents.ShouldNotBeNull();
+
+        await WaitForAsync(() =>
+            documents.VisibleDockables?.OfType<IResourceListViewModel>().Any(x =>
+                ReferenceEquals(x.Cluster, workspace)
+                && x.Kind == GroupApiVersionKind.From(updatedType)
+                && x.ResourceConfig.Type == updatedType
+                && x.ItemCount == 1) == true);
+
+        var openedDocument = documents.VisibleDockables!
+            .OfType<IResourceListViewModel>()
+            .Single(x => ReferenceEquals(x.Cluster, workspace) && x.Kind == GroupApiVersionKind.From(updatedType));
+
+        openedDocument.ResourceConfig.Type.ShouldBe(updatedType);
+        openedDocument.ItemCount.ShouldBe(1);
     }
 
     [AvaloniaFact]

--- a/tests/KubeUI.Kubernetes.Tests/ClusterAuthTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/ClusterAuthTests.cs
@@ -1,4 +1,7 @@
+using System.Collections.Concurrent;
+using System.Reflection;
 using k8s.Models;
+using KubernetesClient.Informer.Client;
 using KubernetesCRDModelGen;
 using KubeUI.Kubernetes;
 using KubeUI.Testing;
@@ -39,6 +42,40 @@ public sealed class ClusterAuthTests
         });
 
         cluster.CanIAnyNamespace<V1Pod>(Verb.Create, "portforward").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void removing_seeded_resource_container_also_clears_cached_seed_task()
+    {
+        using var loggerFactory = NullLoggerFactory.Instance;
+        var cluster = new Cluster(
+            NullLogger<Cluster>.Instance,
+            loggerFactory,
+            new ModelCache(),
+            new Generator(),
+            new TestClusterSettingsStore(),
+            new ServiceCollection().BuildServiceProvider());
+
+        var kind = GroupApiVersionKind.From<V1Pod>();
+        cluster.Objects[kind] = new ContainerClass<V1Pod>
+        {
+            Initialized = true,
+        };
+
+        var seedTasksField = typeof(Cluster).GetField("_seedTasks", BindingFlags.Instance | BindingFlags.NonPublic);
+        seedTasksField.ShouldNotBeNull();
+
+        var seedTasks = seedTasksField!.GetValue(cluster).ShouldBeOfType<ConcurrentDictionary<GroupApiVersionKind, Lazy<Task>>>();
+        seedTasks[kind] = new Lazy<Task>(() => Task.CompletedTask);
+
+        var invalidateSeededResourceMethod = typeof(Cluster).GetMethod("InvalidateSeededResource", BindingFlags.Instance | BindingFlags.NonPublic);
+        invalidateSeededResourceMethod.ShouldNotBeNull();
+
+        var invalidated = invalidateSeededResourceMethod!.Invoke(cluster, [typeof(V1Pod)]).ShouldBeOfType<bool>();
+
+        invalidated.ShouldBeTrue();
+        cluster.Objects.ContainsKey(kind).ShouldBeFalse();
+        seedTasks.ContainsKey(kind).ShouldBeFalse();
     }
 
     private sealed class TestClusterSettingsStore : IClusterSettingsStore


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource list documents to properly reload when custom resource definitions are updated, ensuring the UI reflects the latest CRD changes.
  * Improved handling of outdated resource navigation links after CRD updates—navigating to a previously captured link now opens the current resource list with the correct updated definition.

* **Tests**
  * Added test coverage for CRD update and resource list reload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->