### PR TITLE
fix: Refactor resource seeding and view metric naming

### DIFF
--- a/src/KubeUI.Avalonia/Features/Clusters/Workspace/ViewModels/ClusterWorkspaceViewModel.cs
+++ b/src/KubeUI.Avalonia/Features/Clusters/Workspace/ViewModels/ClusterWorkspaceViewModel.cs
@@ -670,7 +670,7 @@ public sealed partial class ClusterWorkspaceViewModel : ViewModelBase, IClusterR
 
         if (await CanSeedEventsAsync().ConfigureAwait(false))
         {
-            await SeedResource<Corev1Event>(waitForReady: true).ConfigureAwait(false);
+            await SeedResource<Corev1Event>().ConfigureAwait(false);
         }
     }
 

--- a/src/KubeUI.Avalonia/Infrastructure/Presentation/ViewLocator.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/Presentation/ViewLocator.cs
@@ -34,7 +34,7 @@ public sealed class ViewLocator : IDataTemplate
         if (viewType is not null)
         {
             var instance = _serviceProvider.GetRequiredService(viewType);
-            _instrumentation.ViewOpened.Add(1, new TagList { { "view", GetPrettyName(instance.GetType()) } });
+            _instrumentation.ViewOpened.Add(1, new TagList { { "view", GetViewMetricName(instance.GetType(), modelType) } });
             return (Control)instance;
         }
 
@@ -117,6 +117,17 @@ public sealed class ViewLocator : IDataTemplate
         return $"{genericTypeName}<{string.Join(", ", argumentNames)}>";
     }
 
+    private static string GetViewMetricName(Type viewType, Type modelType)
+    {
+        if (viewType.IsGenericType || !modelType.IsGenericType)
+        {
+            return GetPrettyName(viewType);
+        }
+
+        var argumentNames = modelType.GetGenericArguments().Select(GetPrettyName);
+        return $"{viewType.Name}<{string.Join(", ", argumentNames)}>";
+    }
+
     private static string GetUnboundFullName(Type type)
     {
         var fullName = type.IsGenericType ? type.GetGenericTypeDefinition().FullName : type.FullName;
@@ -126,7 +137,6 @@ public sealed class ViewLocator : IDataTemplate
         return genericTypeIndex >= 0 ? fullName[..genericTypeIndex] : fullName;
     }
 }
-
 
 
 

--- a/src/KubeUI.Avalonia/Shell/Navigation/ViewModels/NavigationViewModel.cs
+++ b/src/KubeUI.Avalonia/Shell/Navigation/ViewModels/NavigationViewModel.cs
@@ -1062,12 +1062,6 @@ public sealed partial class NavigationViewModel : ViewModelBase, IDisposable
 
     private static void UpdateNavigationItem(NavigationItem current, NavigationItem desired)
     {
-        var replaceResourceCount = current is ResourceNavigationLink countCurrent
-            && desired is ResourceNavigationLink countDesired
-            && (countCurrent.Count == null
-                || !ReferenceEquals(countCurrent.Cluster, countDesired.Cluster)
-                || countCurrent.ControlType != countDesired.ControlType);
-
         current.Id = desired.Id;
         current.Name = desired.Name;
         current.Order = desired.Order;
@@ -1084,11 +1078,7 @@ public sealed partial class NavigationViewModel : ViewModelBase, IDisposable
 
         if (current is ResourceNavigationLink currentResourceLink && desired is ResourceNavigationLink desiredResourceLink)
         {
-            if (replaceResourceCount)
-            {
-                currentResourceLink.Count = desiredResourceLink.Count;
-            }
-
+            currentResourceLink.Count = desiredResourceLink.Count;
             currentResourceLink.OpenCommand = desiredResourceLink.OpenCommand;
             currentResourceLink.OpenInNewTabCommand = desiredResourceLink.OpenInNewTabCommand;
         }

--- a/tests/KubeUI.Avalonia.Tests/Features/Clusters/Workspace/ClusterWorkspaceViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Clusters/Workspace/ClusterWorkspaceViewModelTests.cs
@@ -707,6 +707,7 @@ internal sealed class CountingClusterRuntime : IClusterRuntime, INotifyPropertyC
         if (typeof(T) == typeof(global::k8s.Models.Corev1Event))
         {
             EventSeedCalls++;
+            EventSeedWaitForReady = waitForReady;
         }
 
         return _inner.SeedResource<T>(waitForReady);

--- a/tests/KubeUI.Avalonia.Tests/Features/Clusters/Workspace/ClusterWorkspaceViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Clusters/Workspace/ClusterWorkspaceViewModelTests.cs
@@ -156,6 +156,45 @@ public class ClusterWorkspaceViewModelTests : AvaloniaTestBase
     }
 
     [AvaloniaFact]
+    public async Task event_resource_seeding_uses_default_wait_for_ready_behavior()
+    {
+        var runtime = new TestClusterRuntime();
+        var countingRuntime = new CountingClusterRuntime(runtime)
+        {
+            Connected = true,
+            Status = ClusterStatus.Connected,
+        };
+
+        var workspace = ActivatorUtilities.CreateInstance<ClusterWorkspaceViewModel>(
+            TestApp.CurrentServices ?? throw new InvalidOperationException("Test services are not initialized."),
+            countingRuntime);
+        _disposables.Add(workspace);
+
+        await workspace.EnsureWorkspaceStateInitializedAsync();
+
+        countingRuntime.EventSeedCalls.ShouldBe(1);
+        (countingRuntime.EventSeedWaitForReady == false).ShouldBeTrue();
+    }
+
+    [AvaloniaFact]
+    public async Task event_resource_seeding_does_not_use_wait_for_ready()
+    {
+        var runtime = new TestClusterRuntime();
+        var countingRuntime = new CountingClusterRuntime(runtime)
+        {
+            Connected = true,
+            Status = ClusterStatus.Connected,
+        };
+
+        var workspace = CreateWorkspace(countingRuntime);
+
+        await workspace.EnsureWorkspaceStateInitializedAsync();
+
+        countingRuntime.EventSeedCalls.ShouldBe(1);
+        (countingRuntime.EventSeedWaitForReady == false).ShouldBeTrue();
+    }
+
+    [AvaloniaFact]
     public async Task initializing_workspace_seeds_custom_resource_definitions_when_allowed()
     {
         var runtime = new TestCluster
@@ -487,6 +526,16 @@ public class ClusterWorkspaceViewModelTests : AvaloniaTestBase
         return workspace;
     }
 
+    private ClusterWorkspaceViewModel CreateWorkspace(IClusterRuntime runtime)
+    {
+        var workspace = ActivatorUtilities.CreateInstance<ClusterWorkspaceViewModel>(
+            TestApp.CurrentServices ?? throw new InvalidOperationException("Test services are not initialized."),
+            runtime);
+
+        _disposables.Add(workspace);
+        return workspace;
+    }
+
     private static async Task WaitForAsync(Func<bool> predicate, int timeoutMs = 10000)
     {
         var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
@@ -588,6 +637,7 @@ internal sealed class CountingClusterRuntime : IClusterRuntime, INotifyPropertyC
     }
 
     public int EventSeedCalls { get; private set; }
+    public bool EventSeedWaitForReady { get; private set; }
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public event Action<WatchEventType, GroupApiVersionKind, IKubernetesObject<V1ObjectMeta>>? OnChange
@@ -654,7 +704,7 @@ internal sealed class CountingClusterRuntime : IClusterRuntime, INotifyPropertyC
 
     public Task SeedResource<T>(bool waitForReady = false) where T : class, IKubernetesObject<V1ObjectMeta>, new()
     {
-        if (typeof(T) == typeof(Corev1Event))
+        if (typeof(T) == typeof(global::k8s.Models.Corev1Event))
         {
             EventSeedCalls++;
         }

--- a/tests/KubeUI.Avalonia.Tests/Infrastructure/Presentation/ViewLocatorTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Infrastructure/Presentation/ViewLocatorTests.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics.Metrics;
+using Avalonia.Headless.XUnit;
+using k8s.Models;
+using KubeUI.Avalonia.Infrastructure.Presentation;
+using KubeUI.Avalonia.Tests.Infra;
+using Shouldly;
+
+namespace KubeUI.Avalonia.Tests.Infrastructure.Presentation;
+
+public sealed class ViewLocatorTests : AvaloniaTestBase
+{
+    [AvaloniaFact]
+    public void Build_EmitsGenericResourceListViewMetricName()
+    {
+        var measurements = new List<string>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == Instrumentation.MeterName && instrument.Name == Instrumentation.MeterName + "_view_opened")
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "view" && tag.Value is string view)
+                {
+                    measurements.Add(view);
+                }
+            }
+        });
+        listener.Start();
+
+        var services = TestApp.CurrentServices ?? throw new InvalidOperationException("Test services are not initialized.");
+        var locator = services.GetRequiredService<ViewLocator>();
+        var viewModel = services.GetRequiredService<ResourceListViewModel<V1Pod>>();
+
+        var view = locator.Build(viewModel);
+
+        view.ShouldBeOfType<ResourceListView>();
+        measurements.ShouldContain("ResourceListView<V1Pod>");
+    }
+}

--- a/tests/KubeUI.Avalonia.Tests/Shell/Navigation/NavigationViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Shell/Navigation/NavigationViewModelTests.cs
@@ -2151,7 +2151,7 @@ public class NavigationViewModelTests : AvaloniaTestBase
             timeoutMs: 10000);
         updatedLink.ShouldNotBeNull();
         ReferenceEquals(originalLink, updatedLink).ShouldBeTrue();
-        ReferenceEquals(originalCount, updatedLink.Count).ShouldBeTrue();
+        ReferenceEquals(originalCount, updatedLink.Count).ShouldBeFalse();
     }
 
     [AvaloniaFact]

--- a/tests/KubeUI.Avalonia.Tests/Shell/Navigation/NavigationViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Shell/Navigation/NavigationViewModelTests.cs
@@ -1864,6 +1864,53 @@ public class NavigationViewModelTests : AvaloniaTestBase
     }
 
     [AvaloniaFact]
+    public async Task resource_navigation_count_is_replaced_when_existing_link_is_updated()
+    {
+        var runtime = new TestCluster
+        {
+            Connected = true,
+            Status = ClusterStatus.Connected,
+        };
+
+        var workspace = CreateWorkspace(runtime);
+
+        var current = new ResourceNavigationLink
+        {
+            Cluster = workspace,
+            Id = "cluster-events",
+            Name = "Events",
+            ControlType = typeof(Corev1Event),
+            Order = 1,
+            Count = Observable.Return(1),
+            OpenCommand = new RelayCommand(() => { }),
+            OpenInNewTabCommand = new RelayCommand(() => { }),
+        };
+
+        var desiredCount = Observable.Return(2);
+        var desired = new ResourceNavigationLink
+        {
+            Cluster = workspace,
+            Id = "cluster-events",
+            Name = "Events",
+            ControlType = typeof(Corev1Event),
+            Order = 1,
+            Count = desiredCount,
+            OpenCommand = new RelayCommand(() => { }),
+            OpenInNewTabCommand = new RelayCommand(() => { }),
+        };
+
+        var method = typeof(NavigationViewModel).GetMethod("UpdateNavigationItem", BindingFlags.Static | BindingFlags.NonPublic);
+        method.ShouldNotBeNull();
+
+        method.Invoke(null, [current, desired]);
+
+        current.Count.ShouldBeSameAs(desiredCount);
+
+        var count = await WaitForCountAsync(current.Count, timeoutMs: 1000);
+        count.ShouldBe(2);
+    }
+
+    [AvaloniaFact]
     public async Task event_navigation_count_recovers_when_event_seed_happened_before_namespace_permission()
     {
         var runtime = new TestCluster


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation item count updates to always reflect the current state
  * Improved event resource seeding to be non-blocking during initialization

* **Tests**
  * Added comprehensive test coverage for event seeding behavior, view metrics, and navigation item count updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->