### PR TITLE
fix: mac os unable to find kubelogin

### DIFF
--- a/src/KubeUI.Desktop/Program.cs
+++ b/src/KubeUI.Desktop/Program.cs
@@ -28,6 +28,8 @@ internal static class Program
     {
         VelopackApp.Build().Run();
 
+        EnsureMacOsPath();
+        
         EnsureHostInitialized();
 
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
@@ -177,6 +179,36 @@ internal static class Program
             ;
 
         return services;
+    }
+
+    private static void EnsureMacOsPath()
+    {
+        if (!OperatingSystem.IsMacOS())
+            return;
+    
+        var existingPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+    
+        var extraPaths = new[]
+        {
+            "/usr/local/bin",
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin"
+        };
+    
+        var pathParts = existingPath
+            .Split(':', StringSplitOptions.RemoveEmptyEntries)
+            .ToHashSet(StringComparer.Ordinal);
+    
+        foreach (var path in extraPaths)
+        {
+            pathParts.Add(path);
+        }
+    
+        Environment.SetEnvironmentVariable("PATH", string.Join(":", pathParts));
     }
 }
 

--- a/src/KubeUI.Desktop/Program.cs
+++ b/src/KubeUI.Desktop/Program.cs
@@ -186,30 +186,30 @@ internal static class Program
         if (!OperatingSystem.IsMacOS())
             return;
     
-        var existingPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-    
-        var extraPaths = new[]
+        var macOsDefaultPaths = new[]
         {
-            "/usr/local/bin",
             "/opt/homebrew/bin",
             "/opt/homebrew/sbin",
+            "/usr/local/bin",
             "/usr/bin",
             "/bin",
             "/usr/sbin",
             "/sbin"
         };
     
-        var pathParts = existingPath
-            .Split(':', StringSplitOptions.RemoveEmptyEntries)
-            .ToHashSet(StringComparer.Ordinal);
+        var existingPath = Environment.GetEnvironmentVariable("PATH");
     
-        foreach (var path in extraPaths)
+        var paths = existingPath?
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList()
+            ?? [];
+    
+        foreach (var path in macOsDefaultPaths)
         {
-            pathParts.Add(path);
+            if (!paths.Contains(path, StringComparer.Ordinal))
+                paths.Add(path);
         }
     
-        Environment.SetEnvironmentVariable("PATH", string.Join(":", pathParts));
+        Environment.SetEnvironmentVariable("PATH", string.Join(Path.PathSeparator, paths));
     }
 }
-
-

--- a/src/KubeUI.Desktop/info.plist
+++ b/src/KubeUI.Desktop/info.plist
@@ -27,7 +27,7 @@
     <key>LSEnvironment</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin</string>
+        <string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     </dict>
   </dict>
 </plist>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * macOS startup now configures the environment PATH earlier so the app and launched tools reliably find Homebrew and standard Unix binaries.
* **Bug Fixes**
  * PATH search order on macOS was adjusted to prefer Homebrew locations before system directories for consistent tool discovery and startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->