### PR TITLE
fix(YamlEditor): Backspace not working

### DIFF
--- a/src/KubeUI.Avalonia/Features/Resources/Yaml/Views/ResourceYamlView.axaml
+++ b/src/KubeUI.Avalonia/Features/Resources/Yaml/Views/ResourceYamlView.axaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="KubeUI.Avalonia.Features.Resources.Yaml.Views.ResourceYamlView"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -143,7 +143,6 @@
                     </MenuItem>
                     <MenuItem
                         Header="{x:Static assets:Resources.Action_Delete}"
-                        HotKey="Back"
                         IsVisible="{Binding EditMode}">
                         <Interaction.Behaviors>
                             <ia:EventTriggerBehavior EventName="Click">
@@ -188,3 +187,4 @@
         </ae:TextEditor>
     </Grid>
 </UserControl>
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the Back key shortcut from the Delete action in the YAML editor context menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IvanJosipovic/KubeUI/pull/1331)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->