### PR TITLE
chore: add timeout blame to tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,32 +20,32 @@ jobs:
         run: dotnet build -c Release
 
       - name: Test Avalonia
-        run: dotnet test \
-          --project tests/KubeUI.Avalonia.Tests/KubeUI.Avalonia.Tests.csproj \
-          -c Release \
-          --no-build \
-          --blame-hang \
-          --blame-hang-timeout 1m \
-          --blame-hang-dump-type mini \
-          --report-xunit-trx \
-          --report-xunit-trx-filename test-results.trx \
-          --coverage \
-          --coverage-output-format cobertura \
-          --coverage-output coverage.cobertura.xml
+        run: |
+          dotnet test \
+            --project tests/KubeUI.Avalonia.Tests/KubeUI.Avalonia.Tests.csproj \
+            -c Release \
+            --no-build \
+            --hangdump \
+            --hangdump-timeout 1m \
+            --report-xunit-trx \
+            --report-xunit-trx-filename test-results.trx \
+            --coverage \
+            --coverage-output-format cobertura \
+            --coverage-output coverage.cobertura.xml
 
       - name: Test Kubernetes E2E
-        run: dotnet test \
-          --project tests/KubeUI.Kubernetes.Tests/KubeUI.Kubernetes.Tests.csproj \
-          -c Release \
-          --no-build \
-          --blame-hang \
-          --blame-hang-timeout 1m \
-          --blame-hang-dump-type mini \
-          --report-xunit-trx \
-          --report-xunit-trx-filename test-results.trx \
-          --coverage \
-          --coverage-output-format cobertura \
-          --coverage-output coverage.cobertura.xml
+        run: |
+          dotnet test \
+            --project tests/KubeUI.Kubernetes.Tests/KubeUI.Kubernetes.Tests.csproj \
+            -c Release \
+            --no-build \
+            --hangdump \
+            --hangdump-timeout 1m \
+            --report-xunit-trx \
+            --report-xunit-trx-filename test-results.trx \
+            --coverage \
+            --coverage-output-format cobertura \
+            --coverage-output coverage.cobertura.xml
         env:
           KUBEUI_RUN_KIND_TESTS: 1
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,10 +20,32 @@ jobs:
         run: dotnet build -c Release
 
       - name: Test Avalonia
-        run: dotnet test --project tests/KubeUI.Avalonia.Tests/KubeUI.Avalonia.Tests.csproj -c Release --no-build --report-xunit-trx --report-xunit-trx-filename test-results.trx --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
+        run: dotnet test \
+          --project tests/KubeUI.Avalonia.Tests/KubeUI.Avalonia.Tests.csproj \
+          -c Release \
+          --no-build \
+          --blame-hang \
+          --blame-hang-timeout 1m \
+          --blame-hang-dump-type mini \
+          --report-xunit-trx \
+          --report-xunit-trx-filename test-results.trx \
+          --coverage \
+          --coverage-output-format cobertura \
+          --coverage-output coverage.cobertura.xml
 
       - name: Test Kubernetes E2E
-        run: dotnet test --project tests/KubeUI.Kubernetes.Tests/KubeUI.Kubernetes.Tests.csproj -c Release --no-build --report-xunit-trx --report-xunit-trx-filename test-results.trx --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
+        run: dotnet test \
+          --project tests/KubeUI.Kubernetes.Tests/KubeUI.Kubernetes.Tests.csproj \
+          -c Release \
+          --no-build \
+          --blame-hang \
+          --blame-hang-timeout 1m \
+          --blame-hang-dump-type mini \
+          --report-xunit-trx \
+          --report-xunit-trx-filename test-results.trx \
+          --coverage \
+          --coverage-output-format cobertura \
+          --coverage-output coverage.cobertura.xml
         env:
           KUBEUI_RUN_KIND_TESTS: 1
 

--- a/tests/KubeUI.Avalonia.Tests/KubeUI.Avalonia.Tests.csproj
+++ b/tests/KubeUI.Avalonia.Tests/KubeUI.Avalonia.Tests.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.4" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.2.3" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/tests/KubeUI.Kubernetes.Tests/KubeUI.Kubernetes.Tests.csproj
+++ b/tests/KubeUI.Kubernetes.Tests/KubeUI.Kubernetes.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.10.2" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.2.3" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to improve test diagnostics and emit Cobertura coverage reports.
* **Tests**
  * Test projects now include hang-dump support to capture hangs during test runs and enable enhanced diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->