### PR TITLE
fix(Visualization): namespace selection bugs and add related tests

### DIFF
--- a/src/KubeUI.Avalonia/Features/Resources/Visualization/VisualizationViewModel.cs
+++ b/src/KubeUI.Avalonia/Features/Resources/Visualization/VisualizationViewModel.cs
@@ -973,7 +973,7 @@ public sealed partial class VisualizationViewModel : ViewModelBase, IInitializeC
             _ = SeedResourceOffUiThreadAsync(cluster.Runtime, resourceConfig.Type);
         }
 
-        ApplyGraph(FilterToCurrentScope(_completeGraph));
+        Run();
 
         var ownerReferenceFound = false;
         IReadOnlyList<IKubernetesObject<V1ObjectMeta>> resources = _resourcesByKey.Values.ToArray();
@@ -1193,24 +1193,6 @@ public sealed partial class VisualizationViewModel : ViewModelBase, IInitializeC
         bool HideNoise,
         int Version);
 
-    private ResourceRelationshipGraph FilterToCurrentScope(ResourceRelationshipGraph graph)
-    {
-        if (RootResource is { } root)
-        {
-            return FilterToRootResource(graph, root);
-        }
-
-        if (Cluster == null && SelectedNamespaces.Count == 0)
-        {
-            return graph;
-        }
-
-        var namespaces = SelectedNamespaces
-            .Select(selectedNamespace => selectedNamespace.Name())
-            .OfType<string>()
-            .ToHashSet(StringComparer.Ordinal);
-        return FilterToSelectedNamespaces(graph, namespaces);
-    }
     private ResourceRelationshipGraph BuildGraph(
         IReadOnlyList<IKubernetesObject<V1ObjectMeta>> source,
         IKubernetesObject<V1ObjectMeta>? root,

--- a/src/KubeUI.Avalonia/Features/Resources/Visualization/VisualizationViewModel.cs
+++ b/src/KubeUI.Avalonia/Features/Resources/Visualization/VisualizationViewModel.cs
@@ -296,7 +296,6 @@ public sealed partial class VisualizationViewModel : ViewModelBase, IInitializeC
             await Dispatcher.UIThread.InvokeAsync(() => ApplyGraphAsync(graph));
             return;
         }
-
         var pendingReferences = _pendingReferences.ToHashSet();
         var selectedTypes = SelectedResourceTypes.ToHashSet(StringComparer.Ordinal);
         var excludedTypes = _excludedResourceTypes.ToHashSet(StringComparer.Ordinal);
@@ -974,7 +973,7 @@ public sealed partial class VisualizationViewModel : ViewModelBase, IInitializeC
             _ = SeedResourceOffUiThreadAsync(cluster.Runtime, resourceConfig.Type);
         }
 
-        ApplyGraph(_completeGraph);
+        ApplyGraph(FilterToCurrentScope(_completeGraph));
 
         var ownerReferenceFound = false;
         IReadOnlyList<IKubernetesObject<V1ObjectMeta>> resources = _resourcesByKey.Values.ToArray();
@@ -1128,6 +1127,12 @@ public sealed partial class VisualizationViewModel : ViewModelBase, IInitializeC
         var cluster = Cluster;
         if (cluster == null || (RootResource == null && SelectedNamespaces.Count == 0))
         {
+            _pendingRebuild = null;
+            _rebuildCancellation?.Cancel();
+            Interlocked.Increment(ref _graphApplicationVersion);
+            Interlocked.Increment(ref _filterVersion);
+            _pendingReferences.Clear();
+            _completeGraph = ResourceRelationshipGraph.Empty;
             Graph = ResourceRelationshipGraph.Empty;
             return;
         }
@@ -1188,6 +1193,24 @@ public sealed partial class VisualizationViewModel : ViewModelBase, IInitializeC
         bool HideNoise,
         int Version);
 
+    private ResourceRelationshipGraph FilterToCurrentScope(ResourceRelationshipGraph graph)
+    {
+        if (RootResource is { } root)
+        {
+            return FilterToRootResource(graph, root);
+        }
+
+        if (Cluster == null && SelectedNamespaces.Count == 0)
+        {
+            return graph;
+        }
+
+        var namespaces = SelectedNamespaces
+            .Select(selectedNamespace => selectedNamespace.Name())
+            .OfType<string>()
+            .ToHashSet(StringComparer.Ordinal);
+        return FilterToSelectedNamespaces(graph, namespaces);
+    }
     private ResourceRelationshipGraph BuildGraph(
         IReadOnlyList<IKubernetesObject<V1ObjectMeta>> source,
         IKubernetesObject<V1ObjectMeta>? root,

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/List/ResourceListViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/List/ResourceListViewModelTests.cs
@@ -1813,6 +1813,7 @@ public class ResourceListViewModelTests
             await AddOrUpdateAsync(cluster, Pod("ns", i.ToString()));
         }
 
+        await WaitForAsync(() => vm.View.Count == 400, 5000);
         await TestApplicationExtensions.WaitForUiAsync();
 
         factory.SetActiveDockable(vm);
@@ -1835,7 +1836,7 @@ public class ResourceListViewModelTests
 
         var targetOffset = new Vector(0, Math.Max(0, scrollViewer.Extent.Height - scrollViewer.Viewport.Height));
         scrollViewer.Offset = targetOffset;
-        await TestApplicationExtensions.WaitForUiAsync();
+        await WaitForAsync(() => Math.Abs(scrollViewer.Offset.Y - targetOffset.Y) < 0.1, 5000);
 
         // switch away to trigger capture
         factory.SetActiveDockable(otherDockable);

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
@@ -981,6 +981,7 @@ public sealed class ResourceGraphControlTests
             config => config.Type = backend,
             connect: false);
         await cluster.Connect();
+        cluster.SelectedNamespaces.Add(new V1Namespace { Metadata = new V1ObjectMeta { Name = "default" } });
 
         var seedRequested = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         void OnResourceSeeded(IClusterRuntime _, GroupApiVersionKind kind)

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/VisualizationViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/VisualizationViewModelTests.cs
@@ -1,0 +1,90 @@
+using k8s;
+using k8s.Models;
+using KubeUI.Avalonia.Features.Resources.Visualization;
+using KubeUI.Kubernetes.Resources.Relationships;
+using Shouldly;
+
+namespace KubeUI.Avalonia.Tests.Features.Resources.Visualization;
+
+public sealed class VisualizationViewModelTests
+{
+    [Fact]
+    public void selecting_another_namespace_removes_resources_from_previous_selection()
+    {
+        V1Pod podA = Pod("namespace-a", "pod-a");
+        V1Pod podB = Pod("namespace-b", "pod-b");
+        ResourceRelationshipGraph graph = Graph(podA, podB);
+
+        ResourceRelationshipGraph selectedA = VisualizationViewModel.FilterToSelectedNamespaces(
+            graph,
+            new HashSet<string>(["namespace-a"], StringComparer.Ordinal));
+        ResourceRelationshipGraph selectedB = VisualizationViewModel.FilterToSelectedNamespaces(
+            graph,
+            new HashSet<string>(["namespace-b"], StringComparer.Ordinal));
+
+        selectedA.Resources.Select(resource => resource.Name()).ShouldBe(["pod-a"]);
+        selectedB.Resources.Select(resource => resource.Name()).ShouldBe(["pod-b"]);
+    }
+
+    [Fact]
+    public void clearing_namespace_selection_returns_empty_graph()
+    {
+        ResourceRelationshipGraph graph = Graph(Pod("namespace-a", "pod-a"));
+
+        ResourceRelationshipGraph selected = VisualizationViewModel.FilterToSelectedNamespaces(
+            graph,
+            new HashSet<string>(StringComparer.Ordinal));
+
+        selected.Resources.ShouldBeEmpty();
+        selected.Relationships.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void selecting_namespace_preserves_related_cluster_scoped_resource()
+    {
+        V1Pod pod = Pod("namespace-a", "pod-a");
+        V1Node node = new()
+        {
+            ApiVersion = "v1",
+            Kind = "Node",
+            Metadata = new V1ObjectMeta { Name = "node-a", Uid = "node-uid" },
+        };
+        ResourceIdentity podIdentity = Identity(pod);
+        ResourceIdentity nodeIdentity = Identity(node);
+        ResourceRelationshipGraph graph = new(
+            [pod, node],
+            [new ResourceRelationship(nodeIdentity, podIdentity, ResourceRelationshipKind.Reference)]);
+
+        ResourceRelationshipGraph selected = VisualizationViewModel.FilterToSelectedNamespaces(
+            graph,
+            new HashSet<string>(["namespace-a"], StringComparer.Ordinal));
+
+        selected.Resources.Select(resource => resource.Name()).ShouldBe(["pod-a", "node-a"]);
+        selected.Relationships.Count.ShouldBe(1);
+    }
+
+    private static ResourceRelationshipGraph Graph(params V1Pod[] pods)
+        => new(pods, []);
+
+    private static V1Pod Pod(string namespaceName, string name)
+        => new()
+        {
+            ApiVersion = "v1",
+            Kind = "Pod",
+            Metadata = new V1ObjectMeta
+            {
+                NamespaceProperty = namespaceName,
+                Name = name,
+                Uid = $"uid-{name}",
+            },
+        };
+
+    private static ResourceIdentity Identity(IKubernetesObject<V1ObjectMeta> resource)
+        => new(
+            resource.ApiVersion!,
+            resource.Kind!,
+            resource.Namespace(),
+            resource.Name()!,
+            resource.Uid());
+}
+


### PR DESCRIPTION
This pull request addresses several issues related to namespace selection in the visualization view, as well as enhancing the test coverage for these functionalities. 

### Changes Made:
- **Bug Fixes:**
  - Cancelled stale rebuilds when the namespace selection becomes empty.
  - Invalidated stale graph/type-filter applications to prevent old resources from flashing back after deselection or switch.
  - Scoped the `ResourceConfigProcessed` graph replay to the current namespace selection.

- **Test Enhancements:**
  - Added regression tests for selection switch and deselection scenarios in `VisualizationViewModelTests.cs`.
  - Included tests for cluster-scoped relationships to ensure comprehensive coverage.

### Validation:
- The build passes with no errors and 945 warnings.
- All focused namespace tests pass (3/3).
- The visualization suite has 51 out of 52 tests passing, with one existing timeout issue noted.

These changes improve the reliability of namespace selection and ensure that the visualization behaves as expected across different scenarios.