### PR TITLE
chore: Fix flaky Kind CI regression in ResourceGraphControlTests.cs

### DIFF
--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/List/ResourceListViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/List/ResourceListViewModelTests.cs
@@ -1493,6 +1493,7 @@ public class ResourceListViewModelTests
 
         await AddOrUpdateAsync(cluster, Pod("ns1", "a"));
         await AddOrUpdateAsync(cluster, Pod("ns2", "b"));
+        await WaitForAsync(() => vm.View.Count == 2, timeoutMs: 5000);
 
         vm.SelectionModel.Select(0);
 

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
@@ -1428,13 +1428,14 @@ public sealed class ResourceGraphControlTests
             TimeSpan.FromSeconds(5),
             cancellationToken: TestContext.Current.CancellationToken);
 
+        var buildCountBeforeDispose = builder.BuildCount;
         viewModel.Dispose();
         var afterDispose = CreatePod("after-dispose");
         afterDispose.Metadata.Uid = null;
         await cluster.Runtime.AddOrUpdateResource(afterDispose);
         await TestApplicationExtensions.WaitForUiAsync();
 
-        builder.BuildCount.ShouldBe(1);
+        builder.BuildCount.ShouldBe(buildCountBeforeDispose);
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
This pull request addresses a flaky regression in the `ResourceGraphControlTests.cs` file related to the Kind variant of a test. The issue was caused by a timing assumption where the test hard-coded the initial builder count as `1`, which could lead to intermittent failures when another rebuild occurred during the disposal transition.

### Changes made:
- Updated the test to snapshot the settled pre-disposal build count instead of assuming it is always `1`.
- Verified that the Release build and both Fake and Kind test variants now pass successfully.

### Validation:
- Release build: passed
- Fake and Kind variants: 2/2 passed
- No whitespace errors detected

This fix aims to stabilize the CI process by ensuring that the test accurately reflects the expected behavior during disposal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened validation to ensure disposed resource views remain stable when runtime data changes.
  * Improved list-view testing by waiting for filtered resources to appear before selection, increasing test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->