### PR TITLE
feat: implement log entry limit

### DIFF
--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodLogsViewModel.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodLogsViewModel.cs
@@ -101,15 +101,22 @@ public sealed partial class PodLogsViewModel : ViewModelBase, IDisposable
 
                 if (!string.IsNullOrEmpty(log))
                 {
-                    await Dispatcher.UIThread.InvokeAsync(() => AppendLog(log), DispatcherPriority.Background);
+                    await Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        if (ReferenceEquals(_connectionCancellation, connectionCancellation) && !connectionCancellation.IsCancellationRequested)
+                        {
+                            AppendLog(log);
+                        }
+                    }, DispatcherPriority.Background);
                 }
             }
         }
-        catch (OperationCanceledException) when (connectionCancellation.IsCancellationRequested)
+        catch (Exception) when (connectionCancellation.IsCancellationRequested)
         {
         }
-        catch (IOException ex) when (ex.Message.Equals("The request was aborted.", StringComparison.Ordinal))
+        catch (Exception ex)
         {
+            _logger.LogError(ex, "Unable to read pod logs");
         }
     }
 

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodLogsViewModel.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodLogsViewModel.cs
@@ -37,13 +37,13 @@ public sealed partial class PodLogsViewModel : ViewModelBase, IDisposable
     [ObservableProperty]
     public partial Vector ScrollOffset { get; set; }
 
+    internal const int MaxLogEntries = 10_000;
+
     private Stream? _stream;
 
     private StreamReader? _streamReader;
 
-    private readonly int _lines = 100;
-
-    private bool _isConnected;
+    private CancellationTokenSource? _connectionCancellation;
 
     public PodLogsViewModel(ILogger<PodLogsViewModel> logger)
     {
@@ -53,48 +53,75 @@ public sealed partial class PodLogsViewModel : ViewModelBase, IDisposable
 
     public async Task Connect()
     {
+        Disconnect();
+
+        var connectionCancellation = new CancellationTokenSource();
+        _connectionCancellation = connectionCancellation;
+
         try
         {
             Logs.Text = string.Empty;
 
-            _stream = await Cluster!.Runtime.Client!.CoreV1.ReadNamespacedPodLogAsync(Object.Name(), Object.Namespace(), container: ContainerName, tailLines: _lines, previous: Previous, follow: true, pretty: true, timestamps: Timestamps);
+            Stream stream = await Cluster!.Runtime.Client!.CoreV1.ReadNamespacedPodLogAsync(Object.Name(), Object.Namespace(), container: ContainerName, tailLines: 100, previous: Previous, follow: true, pretty: true, timestamps: Timestamps, cancellationToken: connectionCancellation.Token);
 
-            _streamReader = new StreamReader(_stream);
-
-            _isConnected = true;
-
-            _ = Task.Run(async () =>
+            if (connectionCancellation.IsCancellationRequested)
             {
-                while (_isConnected)
-                {
-                    try
-                    {
-                        var log = await _streamReader.ReadLineAsync();
+                stream.Dispose();
+                return;
+            }
 
-                        if (!string.IsNullOrEmpty(log))
-                        {
-                            await Dispatcher.UIThread.InvokeAsync(() => Logs.Insert(Logs.TextLength, log + Environment.NewLine), DispatcherPriority.Background);
-                        }
-                    }
-                    catch (IOException ex) when (ex.Message.Equals("The request was aborted."))
-                    {
-                        _isConnected = false;
+            StreamReader streamReader = new(stream);
+            _stream = stream;
+            _streamReader = streamReader;
 
-                        break;
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        _isConnected = false;
-
-                        break;
-                    }
-                }
-            });
+            _ = ReadLogsAsync(streamReader, connectionCancellation);
+        }
+        catch (OperationCanceledException) when (connectionCancellation.IsCancellationRequested)
+        {
         }
         catch (Exception ex)
         {
             //todo display notification
             _logger.LogError(ex, "Unable to View Logs");
+        }
+    }
+
+    private async Task ReadLogsAsync(StreamReader streamReader, CancellationTokenSource connectionCancellation)
+    {
+        try
+        {
+            while (!connectionCancellation.IsCancellationRequested)
+            {
+                var log = await streamReader.ReadLineAsync(connectionCancellation.Token);
+
+                if (log == null)
+                {
+                    break;
+                }
+
+                if (!string.IsNullOrEmpty(log))
+                {
+                    await Dispatcher.UIThread.InvokeAsync(() => AppendLog(log), DispatcherPriority.Background);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (connectionCancellation.IsCancellationRequested)
+        {
+        }
+        catch (IOException ex) when (ex.Message.Equals("The request was aborted.", StringComparison.Ordinal))
+        {
+        }
+    }
+
+    internal void AppendLog(string log)
+    {
+        Logs.Insert(Logs.TextLength, log + Environment.NewLine);
+
+        var excessLines = Logs.LineCount - (MaxLogEntries + 1);
+        if (excessLines > 0)
+        {
+            var lastLineToRemove = Logs.GetLineByNumber(excessLines);
+            Logs.Remove(0, lastLineToRemove.TotalLength);
         }
     }
 
@@ -116,11 +143,17 @@ public sealed partial class PodLogsViewModel : ViewModelBase, IDisposable
 
     public void Dispose()
     {
-        _isConnected = false;
+        Disconnect();
+    }
 
+    private void Disconnect()
+    {
+        _connectionCancellation?.Cancel();
         _stream?.Dispose();
-
         _streamReader?.Dispose();
+        _connectionCancellation?.Dispose();
+        _connectionCancellation = null;
+        _stream = null;
+        _streamReader = null;
     }
 }
-

--- a/src/KubeUI.Kubernetes/Client/Cluster.Auth.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.Auth.cs
@@ -70,6 +70,16 @@ public partial class Cluster
         activity?.SetTag("kubernetes.subresource", subresource);
     }
 
+    private IEnumerable<string> GetKnownNamespaceNames()
+    {
+        if (Namespaces.Count > 0)
+        {
+            return Namespaces.Select(static item => item.Name()).Where(static name => !string.IsNullOrWhiteSpace(name));
+        }
+
+        return _settings.GetClusterNamespaces(this).Where(static name => !string.IsNullOrWhiteSpace(name));
+    }
+
     private async Task<bool> BuildPermissionAsync(GroupApiVersionKind kind, Verb verb, string? @namespace = null, string? subresource = null)
     {
         using var activity = StartClusterActivity(nameof(BuildPermissionAsync));
@@ -121,7 +131,7 @@ public partial class Cluster
     public bool CanIAnyNamespace(GroupApiVersionKind kind, bool namespaced, Verb verb, string? subresource = null)
     {
         return CanI(kind, verb, subresource: subresource)
-            || (namespaced && Namespaces.Any(item => CanI(kind, verb, item.Name(), subresource)));
+            || (namespaced && GetKnownNamespaceNames().Any(@namespace => CanI(kind, verb, @namespace, subresource)));
     }
 
     public async Task UpdatePermissionsAllNamespaceAsync(GroupApiVersionKind kind, bool namespaced, Verb verb, string? subresource = null)
@@ -132,7 +142,7 @@ public partial class Cluster
             return;
         }
 
-        await Parallel.ForEachAsync(Namespaces.Select(item => item.Name()).Where(static name => !string.IsNullOrWhiteSpace(name)),
+        await Parallel.ForEachAsync(GetKnownNamespaceNames(),
             new ParallelOptions { MaxDegreeOfParallelism = MaximumConcurrentNamespaceAuthorizationReviews },
             async (namespaceName, _) => await BuildPermissionAsync(kind, verb, namespaceName, subresource).ConfigureAwait(false)).ConfigureAwait(false);
     }
@@ -175,7 +185,7 @@ public partial class Cluster
         }
 
         await Parallel.ForEachAsync(
-            Namespaces.Select(static item => item.Name()).Where(static name => !string.IsNullOrWhiteSpace(name)),
+            GetKnownNamespaceNames(),
             new ParallelOptions { MaxDegreeOfParallelism = MaximumConcurrentNamespaceAuthorizationReviews },
             async (@namespace, _) => await UpdateCanI<T>(verb, @namespace, subresource).ConfigureAwait(false)).ConfigureAwait(false);
     }

--- a/tests/KubeUI.Avalonia.Tests/Features/Workloads/Pod/PodLogsViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Workloads/Pod/PodLogsViewModelTests.cs
@@ -20,7 +20,7 @@ public sealed class PodLogsViewModelTests
         }
 
         viewModel.Logs.Text.ShouldNotContain("log-0");
-        viewModel.Logs.Text.ShouldContain("log-1");
+        viewModel.Logs.Text.ShouldStartWith("log-1" + Environment.NewLine);
         viewModel.Logs.Text.ShouldContain($"log-{PodLogsViewModel.MaxLogEntries}");
         viewModel.Logs.LineCount.ShouldBe(PodLogsViewModel.MaxLogEntries + 1);
     }

--- a/tests/KubeUI.Avalonia.Tests/Features/Workloads/Pod/PodLogsViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Workloads/Pod/PodLogsViewModelTests.cs
@@ -1,0 +1,27 @@
+using KubeUI.Avalonia.Resources.Workloads.v1.Pod;
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace KubeUI.Avalonia.Tests.Features.Workloads.Pod;
+
+public sealed class PodLogsViewModelTests
+{
+    [AvaloniaFact]
+    public void append_log_keeps_only_the_newest_entries()
+    {
+        var logger =
+            Application.Current.GetTestServices().GetRequiredService<ILogger<PodLogsViewModel>>();
+        using PodLogsViewModel viewModel = new(logger);
+
+        for (var index = 0; index < PodLogsViewModel.MaxLogEntries + 1; index++)
+        {
+            viewModel.AppendLog($"log-{index}");
+        }
+
+        viewModel.Logs.Text.ShouldNotContain("log-0");
+        viewModel.Logs.Text.ShouldContain("log-1");
+        viewModel.Logs.Text.ShouldContain($"log-{PodLogsViewModel.MaxLogEntries}");
+        viewModel.Logs.LineCount.ShouldBe(PodLogsViewModel.MaxLogEntries + 1);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod log streaming reliability when connections are interrupted or canceled.
  * Prevented overlapping log streams by disconnecting previous connections before starting a new one.
  * Ensured log output remains within the configured limit while retaining the newest entries.
  * Improved permission checks across namespaces when namespace information is loaded from cluster settings.

* **Tests**
  * Added coverage confirming that older log entries are removed when the maximum is exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->