### PR TITLE
fix: Add logging for CRD navigation

### DIFF
--- a/src/KubeUI.Avalonia/Features/Clusters/Workspace/ClusterWorkspace.cs
+++ b/src/KubeUI.Avalonia/Features/Clusters/Workspace/ClusterWorkspace.cs
@@ -380,21 +380,55 @@ public sealed partial class ClusterWorkspace : ObservableObject, IDisposable
             resourceConfig.Initialize(this);
             resourceConfig.Configure(crd);
 
+            _logger.LogDebug(
+                "Custom resource definition discovered for {ClusterName}: Definition={DefinitionName}; ResourceKind={ResourceKind}; Generation={Generation}",
+                Runtime.Name,
+                definitionName,
+                resourceConfig.Kind,
+                generation);
+
             await UpdateResourceConfigPermissionsAndEvaluateAsync(resourceConfig).ConfigureAwait(false);
+
+            _logger.LogDebug(
+                "Custom resource definition access evaluated for {ClusterName}: Definition={DefinitionName}; ResourceKind={ResourceKind}; PermissionsLoaded={PermissionsLoaded}; CanListAndWatch={CanListAndWatch}; Generation={Generation}",
+                Runtime.Name,
+                definitionName,
+                resourceConfig.Kind,
+                resourceConfig.PermissionsLoaded,
+                resourceConfig.CanListAndWatch,
+                generation);
 
             if (!resourceConfig.CanListAndWatch)
             {
+                _logger.LogDebug(
+                    "Custom resource definition skipped for {ClusterName}: list/watch access denied; Definition={DefinitionName}; ResourceKind={ResourceKind}",
+                    Runtime.Name,
+                    definitionName,
+                    resourceConfig.Kind);
                 return;
             }
 
             if (!_customResourceDefinitionGenerations.TryGetValue(definitionName, out var currentGeneration)
                 || currentGeneration != generation)
             {
+                _logger.LogDebug(
+                    "Custom resource definition skipped for {ClusterName}: stale generation; Definition={DefinitionName}; ResourceKind={ResourceKind}; ExpectedGeneration={CurrentGeneration}; Generation={Generation}",
+                    Runtime.Name,
+                    definitionName,
+                    resourceConfig.Kind,
+                    currentGeneration,
+                    generation);
                 return;
             }
 
             RemoveOtherCustomResourceVersions(resourceConfig.Kind);
             _resourceConfigs[resourceConfig.Kind] = resourceConfig;
+            _logger.LogDebug(
+                "Custom resource definition registered for {ClusterName}: Definition={DefinitionName}; ResourceKind={ResourceKind}; ConfigCount={ConfigCount}",
+                Runtime.Name,
+                definitionName,
+                resourceConfig.Kind,
+                _resourceConfigs.Count);
             ProcessResourceConfigPermissionsUpdated(resourceConfig);
         }
         catch (OperationCanceledException) when (_disposeCancellation.IsCancellationRequested)

--- a/src/KubeUI.Avalonia/Shell/Navigation/NavigationResourceSynchronizer.cs
+++ b/src/KubeUI.Avalonia/Shell/Navigation/NavigationResourceSynchronizer.cs
@@ -151,12 +151,26 @@ internal sealed class NavigationResourceSynchronizer
         var rootId = $"{cluster.Runtime.Name}-custom-resource-definitions";
         var root = node.NavigationItems.FirstOrDefault(item => item.Id == rootId);
 
+        _logger.LogDebug(
+            "Custom resource navigation evaluating for {ClusterName}: Changed={ChangedKind}; DefinitionPermissionsLoaded={DefinitionPermissionsLoaded}; DefinitionCanListAndWatch={DefinitionCanListAndWatch}; RootPresent={RootPresent}; ConfigCount={ConfigCount}",
+            cluster.Runtime.Name,
+            changedConfig.Kind,
+            definition.PermissionsLoaded,
+            definition.CanListAndWatch,
+            root is not null,
+            configs.Count);
+
         if (definition is not { PermissionsLoaded: true, CanListAndWatch: true })
         {
             if (root != null)
             {
                 node.NavigationItems.Remove(root);
             }
+
+            _logger.LogDebug(
+                "Custom resource navigation hidden for {ClusterName}: Definition access unavailable; RootRemoved={RootRemoved}",
+                cluster.Runtime.Name,
+                root is not null);
 
             return;
         }
@@ -170,6 +184,11 @@ internal sealed class NavigationResourceSynchronizer
                 Order = ResourceCategories.CustomResourceDefinitionsNavigationOrder,
             };
             node.NavigationItems.Add(root);
+
+            _logger.LogDebug(
+                "Custom resource navigation root created for {ClusterName}: RootId={RootId}",
+                cluster.Runtime.Name,
+                rootId);
 
             UpdateCustomResourceLink(root, cluster, definition);
             foreach (var config in configs
@@ -196,6 +215,13 @@ internal sealed class NavigationResourceSynchronizer
                 RemoveEmptyCategories(root.NavigationItems, cluster);
             }
         }
+
+        _logger.LogDebug(
+            "Custom resource navigation updated for {ClusterName}: RootPresent={RootPresent}; RootChildren={RootChildren}; TopLevelItems={TopLevelItems}",
+            cluster.Runtime.Name,
+            node.NavigationItems.Any(item => item.Id == rootId),
+            root.NavigationItems.Count,
+            node.NavigationItems.Count);
     }
 
     private void UpdatePortForwardersNavigation(ClusterNavigationNode node)


### PR DESCRIPTION
This pull request introduces enhanced logging for the Custom Resource Definition (CRD) navigation process and resolves issues with the NuGet restore for the affected projects.

### Changes made:
- **Enhanced Logging**: 
  - Added diagnostic logging around CRD discovery, permission evaluation, stale-generation skips, CRD registration, and navigation root management in `ClusterWorkspace.cs` and `NavigationResourceSynchronizer.cs`.

### Summary of Findings:
- CRD access and navigation were functioning correctly, with no permission or discovery failures.
- The only notable log entries were related to kubeconfig/credential handling, which are not directly related to CRD navigation issues.
- The build process was successfully completed after fixing the NuGet restore issues. 

This update aims to improve the visibility of the CRD navigation process and ensure that the development environment is correctly set up for future work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Diagnostics**
  * Added detailed debug logging for custom resource definition processing.
  * Added diagnostic information for navigation updates, including permission checks, root creation or removal, and final navigation state.
* **Bug Fixes**
  * No functional behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->