### PR TITLE
fix: yaml viewer memory leak prevention

### DIFF
--- a/benchmarks/KubeUI.Benchmarks/FoldingMarginLeakBenchmarks.cs
+++ b/benchmarks/KubeUI.Benchmarks/FoldingMarginLeakBenchmarks.cs
@@ -1,0 +1,59 @@
+using Avalonia.Controls;
+using Avalonia.LogicalTree;
+using AvaloniaEdit.Folding;
+using BenchmarkDotNet.Attributes;
+using KubeUI.Avalonia.Features.Resources.Yaml.Behaviors;
+
+namespace KubeUI.Benchmarks;
+
+[MemoryDiagnoser]
+[BenchmarkCategory("YAML", "Leak")]
+public class FoldingMarginLeakBenchmarks
+{
+    [Params(100, 1_000)]
+    public int RefreshCount { get; set; }
+
+    [Params(10)]
+    public int MarkersPerRefresh { get; set; }
+
+    [Benchmark(Baseline = true)]
+    public int StockLifecycle_RetainedLogicalChildren()
+    {
+        var margin = new FoldingMargin();
+        AddMarkers(margin, RefreshCount, MarkersPerRefresh, clearBeforeRefresh: false);
+        return CountLogicalChildren(margin);
+    }
+
+    [Benchmark]
+    public int LeakSafeLifecycle_RetainedLogicalChildren()
+    {
+        var margin = new FoldingMargin();
+        AddMarkers(margin, RefreshCount, MarkersPerRefresh, clearBeforeRefresh: true);
+        return CountLogicalChildren(margin);
+    }
+
+    private static void AddMarkers(
+        FoldingMargin margin,
+        int refreshCount,
+        int markersPerRefresh,
+        bool clearBeforeRefresh)
+    {
+        for (var refresh = 0; refresh < refreshCount; refresh++)
+        {
+            if (clearBeforeRefresh)
+            {
+                LeakSafeFoldingMargin.ClearLogicalChildren(margin);
+            }
+
+            for (var marker = 0; marker < markersPerRefresh; marker++)
+            {
+                ((ISetLogicalParent)new Control()).SetParent(margin);
+            }
+        }
+    }
+
+    private static int CountLogicalChildren(FoldingMargin margin)
+    {
+        return ((ILogical)margin).LogicalChildren.Count();
+    }
+}

--- a/src/KubeUI.Avalonia/Features/Resources/Yaml/Behaviors/LeakSafeFoldingMargin.cs
+++ b/src/KubeUI.Avalonia/Features/Resources/Yaml/Behaviors/LeakSafeFoldingMargin.cs
@@ -1,0 +1,22 @@
+using Avalonia.LogicalTree;
+using AvaloniaEdit.Folding;
+
+namespace KubeUI.Avalonia.Features.Resources.Yaml.Behaviors;
+
+internal sealed class LeakSafeFoldingMargin : FoldingMargin
+{
+    protected override void OnTextViewVisualLinesChanged()
+    {
+        ClearLogicalChildren(this);
+        base.OnTextViewVisualLinesChanged();
+    }
+
+    internal static void ClearLogicalChildren(FoldingMargin margin)
+    {
+        var children = ((ILogical)margin).LogicalChildren.ToArray();
+        foreach (var child in children)
+        {
+            ((ISetLogicalParent)child).SetParent(null);
+        }
+    }
+}

--- a/src/KubeUI.Avalonia/Features/Resources/Yaml/Behaviors/YamlEditorBehavior.cs
+++ b/src/KubeUI.Avalonia/Features/Resources/Yaml/Behaviors/YamlEditorBehavior.cs
@@ -57,6 +57,7 @@ public sealed class YamlEditorBehavior : Behavior<TextEditor>
     private Installation? _textMateInstallation;
     private RegistryOptions _registryOptions = null!;
     private FoldingManager? _foldingManager;
+    private LeakSafeFoldingMargin? _foldingMargin;
     private ResourceYamlViewModel? _currentViewModel;
     private readonly Dictionary<string, Queue<bool>> _savedFoldStates = new(StringComparer.Ordinal);
     private CompletionWindow? _completionWindow;
@@ -178,6 +179,14 @@ public sealed class YamlEditorBehavior : Behavior<TextEditor>
         if (_foldingManager == null)
         {
             _foldingManager = FoldingManager.Install(AssociatedObject.TextArea);
+            var defaultMargin = AssociatedObject.TextArea.LeftMargins.OfType<FoldingMargin>().Single();
+            _foldingMargin = new LeakSafeFoldingMargin
+            {
+                FoldingManager = defaultMargin.FoldingManager,
+            };
+            var marginIndex = AssociatedObject.TextArea.LeftMargins.IndexOf(defaultMargin);
+            AssociatedObject.TextArea.LeftMargins.RemoveAt(marginIndex);
+            AssociatedObject.TextArea.LeftMargins.Insert(marginIndex, _foldingMargin);
         }
 
         UpdateFoldings();
@@ -237,6 +246,13 @@ public sealed class YamlEditorBehavior : Behavior<TextEditor>
 
         if (_foldingManager != null)
         {
+            if (_foldingMargin != null)
+            {
+                LeakSafeFoldingMargin.ClearLogicalChildren(_foldingMargin);
+                AssociatedObject?.TextArea.LeftMargins.Remove(_foldingMargin);
+                _foldingMargin = null;
+            }
+
             FoldingManager.Uninstall(_foldingManager);
             _foldingManager = null;
         }

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Yaml/ResourceYamlViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Yaml/ResourceYamlViewModelTests.cs
@@ -301,10 +301,14 @@ public class ResourceYamlViewModelTests
 
         for (var refreshIndex = 0; refreshIndex < 3; refreshIndex++)
         {
+            var foldingTitlePrefix = $"value-{refreshIndex}-";
             vm.YamlDocument.Text = string.Join(
                 "\n",
-                Enumerable.Range(0, 300).Select(i => $"value-{refreshIndex}-{i}:\n  nested: {i}"));
-            await WaitForUiAsync(() => foldingManager.AllFoldings.Count() == 300);
+                Enumerable.Range(0, 300).Select(i => $"{foldingTitlePrefix}{i}:\n  nested: {i}"));
+            await WaitForUiAsync(
+                () => foldingManager.AllFoldings.Count() == 300
+                    && foldingManager.AllFoldings.All(folding =>
+                        folding.Title.StartsWith(foldingTitlePrefix, StringComparison.Ordinal)));
             foldingManager.AllFoldings.Count().ShouldBe(300);
 
             for (var lineIndex = 0; lineIndex < 200; lineIndex++)

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Yaml/ResourceYamlViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Yaml/ResourceYamlViewModelTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Primitives.PopupPositioning;
 using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.LogicalTree;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Avalonia.Xaml.Interactivity;
@@ -272,6 +273,42 @@ public class ResourceYamlViewModelTests
 
         vm.HideNoisyFields = true;
         await WaitForUiAsync(() => GetNoisyFoldings().All(folding => folding.IsFolded));
+    }
+
+    [AvaloniaFact]
+    public async Task ResourceYamlView_RepeatedDocumentRefreshesDoNotRetainDetachedFoldingMarkers()
+    {
+        using var window = Application.Current.CreateTestWindow(width: 800, height: 600);
+
+        var cluster = await Application.Current.CreateClusterAsync();
+        var vm = Application.Current.GetRequiredTestService<ResourceYamlViewModel>();
+        vm.Initialize(cluster, new V1Pod { Metadata = new V1ObjectMeta { Name = "test" } });
+
+        var view = Application.Current.GetRequiredTestService<ResourceYamlView>();
+        view.DataContext = vm;
+        window.Content = view;
+        window.Show();
+
+        await TestApplicationExtensions.WaitForUiAsync();
+
+        var editor = view.FindControl<TextEditor>("Editor");
+        editor.ShouldNotBeNull();
+        var foldingMargin = editor.TextArea.LeftMargins.OfType<FoldingMargin>().Single();
+
+        vm.YamlDocument.Text = string.Join(
+            "\n",
+            Enumerable.Range(0, 300).Select(i => $"value-{i}: {i}"));
+        await TestApplicationExtensions.WaitForUiAsync();
+
+        for (var i = 0; i < 200; i++)
+        {
+            editor.ScrollToLine(i);
+            await TestApplicationExtensions.WaitForUiAsync();
+        }
+
+        ((ILogical)foldingMargin).LogicalChildren
+            .Count()
+            .ShouldBeLessThan(100);
     }
 
     [AvaloniaFact]

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Yaml/ResourceYamlViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Yaml/ResourceYamlViewModelTests.cs
@@ -295,25 +295,28 @@ public class ResourceYamlViewModelTests
         editor.ShouldNotBeNull();
         var foldingMargin = editor.TextArea.LeftMargins.OfType<FoldingMargin>().Single();
 
-        vm.YamlDocument.Text = string.Join(
-            "\n",
-            Enumerable.Range(0, 300).Select(i => $"value-{i}:\n  nested: {i}"));
-
         var behavior = Interaction.GetBehaviors(editor).OfType<YamlEditorBehavior>().Single();
         var foldingManager = GetFoldingManager(behavior);
         foldingManager.ShouldNotBeNull();
-        await WaitForUiAsync(() => foldingManager.AllFoldings.Count() == 300);
-        foldingManager.AllFoldings.Count().ShouldBe(300);
 
-        for (var i = 0; i < 200; i++)
+        for (var refreshIndex = 0; refreshIndex < 3; refreshIndex++)
         {
-            editor.ScrollToLine(i);
-            await TestApplicationExtensions.WaitForUiAsync();
-        }
+            vm.YamlDocument.Text = string.Join(
+                "\n",
+                Enumerable.Range(0, 300).Select(i => $"value-{refreshIndex}-{i}:\n  nested: {i}"));
+            await WaitForUiAsync(() => foldingManager.AllFoldings.Count() == 300);
+            foldingManager.AllFoldings.Count().ShouldBe(300);
 
-        ((ILogical)foldingMargin).LogicalChildren
-            .Count()
-            .ShouldBeLessThan(100);
+            for (var lineIndex = 0; lineIndex < 200; lineIndex++)
+            {
+                editor.ScrollToLine(lineIndex);
+                await TestApplicationExtensions.WaitForUiAsync();
+            }
+
+            ((ILogical)foldingMargin).LogicalChildren
+                .Count()
+                .ShouldBeLessThan(100);
+        }
     }
 
     [AvaloniaFact]

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Yaml/ResourceYamlViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Yaml/ResourceYamlViewModelTests.cs
@@ -297,8 +297,13 @@ public class ResourceYamlViewModelTests
 
         vm.YamlDocument.Text = string.Join(
             "\n",
-            Enumerable.Range(0, 300).Select(i => $"value-{i}: {i}"));
-        await TestApplicationExtensions.WaitForUiAsync();
+            Enumerable.Range(0, 300).Select(i => $"value-{i}:\n  nested: {i}"));
+
+        var behavior = Interaction.GetBehaviors(editor).OfType<YamlEditorBehavior>().Single();
+        var foldingManager = GetFoldingManager(behavior);
+        foldingManager.ShouldNotBeNull();
+        await WaitForUiAsync(() => foldingManager.AllFoldings.Count() == 300);
+        foldingManager.AllFoldings.Count().ShouldBe(300);
 
         for (var i = 0; i < 200; i++)
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where YAML editor folding markers could be retained after repeated document refreshes and scrolling.
  - Added safer folding-margin lifecycle handling to ensure detached logical children are cleared and removed promptly.
- **Tests**
  - Enhanced the regression test to more reliably verify folding-marker detachment across repeated refresh iterations.
  - Added benchmarks to measure logical-child retention behavior of the folding margin over repeated refresh cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->