### PR TITLE
fix: improve revert resource key to namespace+name

### DIFF
--- a/benchmarks/KubeUI.Benchmarks/IdentityPreservingSelectionModelBenchmarks.cs
+++ b/benchmarks/KubeUI.Benchmarks/IdentityPreservingSelectionModelBenchmarks.cs
@@ -1,5 +1,4 @@
 using BenchmarkDotNet.Attributes;
-using System.Globalization;
 using KubeUI.Avalonia.Infrastructure.DataGrid;
 
 namespace KubeUI.Benchmarks;
@@ -9,7 +8,7 @@ namespace KubeUI.Benchmarks;
 [BenchmarkCategory("DataGrid", "Selection")]
 public class IdentityPreservingSelectionModelBenchmarks : IDisposable
 {
-    private IdentityPreservingSelectionModel<BenchmarkItem> _model = null!;
+    private IdentityPreservingSelectionModel<BenchmarkItem, string> _model = null!;
     private List<BenchmarkItem> _source = null!;
     private BenchmarkItem[] _orderA = null!;
     private BenchmarkItem[] _orderB = null!;
@@ -20,9 +19,6 @@ public class IdentityPreservingSelectionModelBenchmarks : IDisposable
 
     [Params(1, 10, 100)]
     public int SelectedCount { get; set; }
-
-    [Params("UID", "NameNamespace")]
-    public string IdentityMode { get; set; } = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -39,10 +35,7 @@ public class IdentityPreservingSelectionModelBenchmarks : IDisposable
         Array.Copy(items, selectionCount, _orderB, 0, ItemCount - selectionCount);
         Array.Copy(items, 0, _orderB, ItemCount - selectionCount, selectionCount);
         _source = new List<BenchmarkItem>(items);
-        var useUid = string.Equals(IdentityMode, "UID", StringComparison.Ordinal);
-        _model = new IdentityPreservingSelectionModel<BenchmarkItem>(item => useUid
-            ? item.Uid
-            : string.Create(CultureInfo.InvariantCulture, $"{item.Id}"))
+        _model = new IdentityPreservingSelectionModel<BenchmarkItem, string>(static item => item.Id)
         {
             Source = _source
         };
@@ -79,10 +72,8 @@ public class IdentityPreservingSelectionModelBenchmarks : IDisposable
         public BenchmarkItem(string id)
         {
             Id = id;
-            Uid = $"uid-{id}";
         }
 
         public string Id { get; }
-        public string Uid { get; }
     }
 }

--- a/benchmarks/KubeUI.Benchmarks/ResourceListPipelineBenchmarks.cs
+++ b/benchmarks/KubeUI.Benchmarks/ResourceListPipelineBenchmarks.cs
@@ -11,6 +11,7 @@ using DynamicData;
 using DynamicData.Binding;
 using k8s.Models;
 using KubeUI.Avalonia.Features.Resources.List;
+using KubeUI.Kubernetes;
 using KubeUI.Avalonia.Resources;
 
 namespace KubeUI.Benchmarks;
@@ -20,7 +21,7 @@ namespace KubeUI.Benchmarks;
 [BenchmarkCategory("ResourceList", "DynamicData")]
 public class ResourceListPipelineBenchmarks : IDisposable
 {
-    private SourceCache<V1Pod, string> _cache = null!;
+    private SourceCache<V1Pod, ResourceCacheKey> _cache = null!;
     private BehaviorSubject<Func<V1Pod, bool>> _filterSubject = null!;
     private BehaviorSubject<IComparer<V1Pod>> _sortSubject = null!;
     private IDisposable _subscription = null!;
@@ -51,7 +52,7 @@ public class ResourceListPipelineBenchmarks : IDisposable
         _ascendingComparer = Comparer<V1Pod>.Create(static (left, right) => string.CompareOrdinal(left.Name(), right.Name()));
         _descendingComparer = Comparer<V1Pod>.Create(static (left, right) => string.CompareOrdinal(right.Name(), left.Name()));
 
-        _cache = new SourceCache<V1Pod, string>(pod => pod.Name());
+        _cache = new SourceCache<V1Pod, ResourceCacheKey>(ResourceCacheKey.From);
         _filterSubject = new(_nonMatchingFilter);
         _sortSubject = new(_ascendingComparer);
         _subscription = _cache.Connect()

--- a/benchmarks/KubeUI.Benchmarks/VisualizationPipelineBenchmarks.cs
+++ b/benchmarks/KubeUI.Benchmarks/VisualizationPipelineBenchmarks.cs
@@ -31,7 +31,6 @@ public class VisualizationPipelineBenchmarks
                 {
                     NamespaceProperty = index % 2 == 0 ? "namespace-a" : "namespace-b",
                     Name = $"pod-{index}",
-                    Uid = $"uid-{index}",
                 },
             });
         }

--- a/src/KubeUI.Avalonia/Features/Resources/List/ResourceListViewModel.cs
+++ b/src/KubeUI.Avalonia/Features/Resources/List/ResourceListViewModel.cs
@@ -51,7 +51,7 @@ public partial class ResourceListViewModel<T> : ViewModelBase, IInitializeCluste
     public GroupApiVersionKind Kind => _kind;
 
     [ObservableProperty]
-    public partial ISourceCache<T, string> Objects { get; set; }
+    public partial ISourceCache<T, ResourceCacheKey> Objects { get; set; }
 
     public T? SelectedItem => _selectionModel.SelectedItem as T;
 
@@ -76,7 +76,7 @@ public partial class ResourceListViewModel<T> : ViewModelBase, IInitializeCluste
     private readonly Subject<string> _searchQueryChanges = new();
     private readonly IDisposable _searchQuerySubscription;
 
-    private readonly IdentityPreservingSelectionModel<T> _selectionModel = new(GetResourceIdentity)
+    private readonly IdentityPreservingSelectionModel<T, ResourceCacheKey> _selectionModel = new(ResourceCacheKey.From)
     {
         SingleSelect = false
     };
@@ -643,7 +643,7 @@ public partial class ResourceListViewModel<T> : ViewModelBase, IInitializeCluste
             return -1;
         }
 
-        var identity = GetResourceIdentity(resource);
+        var identity = ResourceCacheKey.From(resource);
 
         for (var i = 0; i < list.Count; i++)
         {
@@ -652,7 +652,7 @@ public partial class ResourceListViewModel<T> : ViewModelBase, IInitializeCluste
                 return i;
             }
 
-            if (list[i] is T candidate && string.Equals(GetResourceIdentity(candidate), identity, StringComparison.Ordinal))
+            if (list[i] is T candidate && ResourceCacheKey.From(candidate).Equals(identity))
             {
                 return i;
             }
@@ -661,11 +661,6 @@ public partial class ResourceListViewModel<T> : ViewModelBase, IInitializeCluste
         return -1;
     }
 
-    private static string GetResourceIdentity(T resource)
-    {
-        return resource.Uid() ?? throw new InvalidOperationException(
-            $"Resource {resource.ApiVersion}/{resource.Kind} '{resource.Namespace()}/{resource.Name()}' has no metadata UID.");
-    }
 }
 
 public sealed class DynamicDataSortingAdapterFactory<T> : IDataGridSortingAdapterFactory where T : class, IKubernetesObject<V1ObjectMeta>, new()

--- a/src/KubeUI.Avalonia/Features/Resources/Properties/Controls/ResourceEventsView.cs
+++ b/src/KubeUI.Avalonia/Features/Resources/Properties/Controls/ResourceEventsView.cs
@@ -9,6 +9,7 @@ using k8s.Models;
 using KubeUI.Avalonia.Features.Clusters.Workspace;
 using KubeUI.Avalonia.Infrastructure.Presentation;
 using KubeUI.Avalonia.Infrastructure.Threading;
+using KubeUI.Kubernetes;
 
 namespace KubeUI.Avalonia.Features.Resources.Properties.Controls;
 
@@ -19,7 +20,7 @@ public sealed partial class ResourceEventsView : UserControl, IInitializeCluster
     private static readonly FuncValueConverter<bool, bool> NotConverter = new(value => !value);
     private readonly DispatcherTimer _timer = new(DispatcherPriority.Background);
     private static readonly IReadOnlyList<ResourceEventItem> EmptyItems = Array.Empty<ResourceEventItem>();
-    private ISourceCache<Corev1Event, string>? _eventCache;
+    private ISourceCache<Corev1Event, ResourceCacheKey>? _eventCache;
     private IDisposable? _eventCacheSubscription;
     private readonly ReadOnlyObservableCollection<Corev1Event> _emptyEvents = new([]);
     private ReadOnlyObservableCollection<Corev1Event> _matchedEvents;

--- a/src/KubeUI.Avalonia/Infrastructure/DataGrid/IdentityPreservingSelectionModel.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/DataGrid/IdentityPreservingSelectionModel.cs
@@ -3,14 +3,16 @@ using Avalonia.Controls.Selection;
 
 namespace KubeUI.Avalonia.Infrastructure.DataGrid;
 
-internal sealed class IdentityPreservingSelectionModel<T> : ISelectionModel, INotifyPropertyChanged, IDisposable where T : notnull
+internal sealed class IdentityPreservingSelectionModel<T, TIdentity> : ISelectionModel, INotifyPropertyChanged, IDisposable
+    where T : notnull
+    where TIdentity : notnull
 {
     private readonly SelectionModel<object?> _inner = new();
-    private readonly Func<T, object?> _identitySelector;
-    private readonly List<object> _selectionSnapshot = [];
-    private readonly HashSet<object> _selectionIdentities = [];
+    private readonly Func<T, TIdentity> _identitySelector;
+    private readonly List<TIdentity> _selectionSnapshot = [];
+    private readonly HashSet<TIdentity> _selectionIdentities = [];
     private readonly List<int> _restoredIndexes = [];
-    private readonly Dictionary<T, object?> _identityCache = new();
+    private readonly Dictionary<T, TIdentity> _identityCache = new();
     private INotifyCollectionChanged? _sourceNotifications;
     private IEnumerable? _identitySource;
     private INotifyCollectionChanged? _identitySourceNotifications;
@@ -18,7 +20,7 @@ internal sealed class IdentityPreservingSelectionModel<T> : ISelectionModel, INo
     private bool _suppressSnapshotUpdates;
     private int _sourceChangeVersion;
 
-    public IdentityPreservingSelectionModel(Func<T, object?> identitySelector)
+    public IdentityPreservingSelectionModel(Func<T, TIdentity> identitySelector)
     {
         _identitySelector = identitySelector ?? throw new ArgumentNullException(nameof(identitySelector));
 
@@ -223,7 +225,7 @@ internal sealed class IdentityPreservingSelectionModel<T> : ISelectionModel, INo
         }, DispatcherPriority.Normal);
     }
 
-    private void RestoreSelectionSnapshot(IReadOnlyList<object> snapshot)
+    private void RestoreSelectionSnapshot(IReadOnlyList<TIdentity> snapshot)
     {
         if (snapshot.Count == 0 || Source is null)
         {
@@ -295,7 +297,7 @@ internal sealed class IdentityPreservingSelectionModel<T> : ISelectionModel, INo
         return true;
     }
 
-    private List<int> FindIndexes(IReadOnlyList<object> snapshot)
+    private List<int> FindIndexes(IReadOnlyList<TIdentity> snapshot)
     {
         if (snapshot.Count <= 4)
         {
@@ -306,7 +308,7 @@ internal sealed class IdentityPreservingSelectionModel<T> : ISelectionModel, INo
             {
                 foreach (var item in fastSource)
                 {
-                    if (item is not null && Equals(identity, GetIdentity(item)))
+                    if (item is T typedItem && EqualityComparer<TIdentity>.Default.Equals(identity, GetIdentity(typedItem)))
                     {
                         indexes.Add(fastSourceIndex);
                         break;
@@ -339,7 +341,7 @@ internal sealed class IdentityPreservingSelectionModel<T> : ISelectionModel, INo
                     continue;
                 }
 
-                if (_selectionIdentities.Contains(GetIdentity(item)!))
+                if (item is T typedItem && _selectionIdentities.Contains(GetIdentity(typedItem)))
                 {
                     _restoredIndexes.Add(index);
                 }
@@ -351,7 +353,7 @@ internal sealed class IdentityPreservingSelectionModel<T> : ISelectionModel, INo
         var sourceIndex = 0;
         foreach (var item in source)
         {
-            if (item is not null && _selectionIdentities.Contains(GetIdentity(item)!))
+            if (item is T typedItem && _selectionIdentities.Contains(GetIdentity(typedItem)))
             {
                 _restoredIndexes.Add(sourceIndex);
             }
@@ -362,13 +364,26 @@ internal sealed class IdentityPreservingSelectionModel<T> : ISelectionModel, INo
         return _restoredIndexes;
     }
 
-    private object? GetIdentity(object? item)
+    private bool TryGetIdentity(object? item, out TIdentity identity)
     {
         if (item is not T typedItem)
         {
-            return item;
+            identity = default!;
+            return false;
         }
 
+        if (_identityCache.TryGetValue(typedItem, out identity))
+        {
+            return true;
+        }
+
+        identity = _identitySelector(typedItem);
+        _identityCache.Add(typedItem, identity);
+        return true;
+    }
+
+    private TIdentity GetIdentity(T typedItem)
+    {
         if (_identityCache.TryGetValue(typedItem, out var identity))
         {
             return identity;
@@ -384,8 +399,7 @@ internal sealed class IdentityPreservingSelectionModel<T> : ISelectionModel, INo
         _selectionSnapshot.Clear();
         foreach (var selectedItem in _inner.SelectedItems)
         {
-            var identity = GetIdentity(selectedItem);
-            if (identity is not null)
+            if (TryGetIdentity(selectedItem, out var identity))
             {
                 _selectionSnapshot.Add(identity);
             }

--- a/src/KubeUI.Avalonia/Resources/Network/v1/Service/V1ServiceConfig.cs
+++ b/src/KubeUI.Avalonia/Resources/Network/v1/Service/V1ServiceConfig.cs
@@ -93,7 +93,7 @@ public sealed partial class V1ServiceConfig : ResourceConfigBase<V1Service>
     {
         if (parameters[0] is V1Service service && parameters[1] is V1ServicePort containerPort)
         {
-            var pf = Cluster.Runtime.AddServicePortForward(service.Namespace(), service.Name(), service.Uid(), containerPort.Port);
+            var pf = Cluster.Runtime.AddServicePortForward(service.Namespace(), service.Name(), containerPort.Port);
 
             ContentDialogSettings settings = new()
             {

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/V1PodConfig.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/V1PodConfig.cs
@@ -539,7 +539,7 @@ public sealed partial class V1PodConfig : ResourceConfigBase<V1Pod>
     {
         if (parameters[0] is V1Pod pod && parameters[1] is V1ContainerPort containerPort)
         {
-            var pf = Cluster.Runtime.AddPodPortForward(pod.Namespace(), pod.Name(), pod.Uid(), containerPort.ContainerPort);
+            var pf = Cluster.Runtime.AddPodPortForward(pod.Namespace(), pod.Name(), containerPort.ContainerPort);
 
             ContentDialogSettings settings = new()
             {

--- a/src/KubeUI.Kubernetes/Client/Cluster.PortForward.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.PortForward.cs
@@ -10,13 +10,8 @@ public partial class Cluster
 #pragma warning disable CA2000 // PortForwarders owns forwarders after Add.
     public PortForwarder AddPodPortForward(string @namespace, string podName, int containerPort)
     {
-        return AddPodPortForward(@namespace, podName, null, containerPort);
-    }
-
-    public PortForwarder AddPodPortForward(string @namespace, string podName, string? podUid, int containerPort)
-    {
         var pf = new PortForwarder(this, @namespace, localPort: 0, _portForwardSessionFactory);
-        pf.SetPod(podName, podUid, containerPort);
+        pf.SetPod(podName, containerPort);
 
         var existing = FindPortForwarder(pf);
         if (existing != null)
@@ -32,13 +27,8 @@ public partial class Cluster
 
     public PortForwarder AddServicePortForward(string @namespace, string serviceName, int servicePort)
     {
-        return AddServicePortForward(@namespace, serviceName, null, servicePort);
-    }
-
-    public PortForwarder AddServicePortForward(string @namespace, string serviceName, string? serviceUid, int servicePort)
-    {
         var pf = new PortForwarder(this, @namespace, localPort: 0, _portForwardSessionFactory);
-        pf.SetService(serviceName, serviceUid, servicePort);
+        pf.SetService(serviceName, servicePort);
 
         var existing = FindPortForwarder(pf);
         if (existing != null)

--- a/src/KubeUI.Kubernetes/Client/Cluster.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.cs
@@ -628,12 +628,12 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
         return GetResourceSourceCache<T>().Items;
     }
 
-    public ISourceCache<T, string> GetResourceSourceCache<T>() where T : class, IKubernetesObject<V1ObjectMeta>, new()
+    public ISourceCache<T, ResourceCacheKey> GetResourceSourceCache<T>() where T : class, IKubernetesObject<V1ObjectMeta>, new()
     {
         return GetResourceSourceCache<T>(GroupApiVersionKind.From<T>());
     }
 
-    public ISourceCache<T, string> GetResourceSourceCache<T>(GroupApiVersionKind kind) where T : class, IKubernetesObject<V1ObjectMeta>, new()
+    public ISourceCache<T, ResourceCacheKey> GetResourceSourceCache<T>(GroupApiVersionKind kind) where T : class, IKubernetesObject<V1ObjectMeta>, new()
     {
         if (Objects.TryGetValue(kind, out var obj) && obj is ContainerClass<T> container)
         {
@@ -1055,31 +1055,9 @@ public partial class ContainerClass<T> : ObservableObject, IClearableResourceCon
 
     public bool IsSeeded => InformerCount > 0;
 
-    public ISourceCache<T, string> Items { get; } = new SourceCache<T, string>(GetResourceCacheKey);
+    public ISourceCache<T, ResourceCacheKey> Items { get; } = new SourceCache<T, ResourceCacheKey>(ResourceCacheKey.From);
 
-    public void Remove(T resource)
-    {
-        if (!string.IsNullOrEmpty(resource.Uid()))
-        {
-            Items.Remove(resource);
-            return;
-        }
-
-        var cachedResource = Items.Items.FirstOrDefault(item =>
-            string.Equals(item.Namespace(), resource.Namespace(), StringComparison.Ordinal)
-            && string.Equals(item.Name(), resource.Name(), StringComparison.Ordinal));
-
-        if (cachedResource != null)
-        {
-            Items.Remove(cachedResource);
-        }
-    }
-
-    private static string GetResourceCacheKey(T resource)
-    {
-        return resource.Uid() ?? throw new InvalidOperationException(
-            $"Resource {typeof(T).Name} '{resource.Namespace()}/{resource.Name()}' has no metadata UID.");
-    }
+    public void Remove(T resource) => Items.Remove(resource);
 
     public IObservable<ResourceChange> ConnectChanges(GroupApiVersionKind kind)
     {

--- a/src/KubeUI.Kubernetes/Client/Cluster.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.cs
@@ -412,7 +412,7 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
                         container.Items.AddOrUpdate(generic);
                         break;
                     case WatchEventType.Deleted:
-                        container.Remove(generic);
+                        container.Items.Remove(generic);
                         break;
                 }
 
@@ -474,24 +474,19 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
             var kind = GroupApiVersionKind.From<T>();
             ResourceInformerCallbackGuard.Execute(_logger, eventType, kind, item, () =>
             {
-                if (!Objects.TryGetValue(kind, out var objectContainer)
-                    || objectContainer is not ContainerClass<T> container)
-                {
-                    return;
-                }
-
+                var items = GetResourceSourceCache<T>();
                 switch (eventType)
                 {
                     case WatchEventType.Added:
-                        container.Items.AddOrUpdate(item);
+                        items.AddOrUpdate(item);
                         RegisterCustomResourceDefinition(item as V1CustomResourceDefinition);
                         break;
                     case WatchEventType.Modified:
-                        container.Items.AddOrUpdate(item);
+                        items.AddOrUpdate(item);
                         RegisterCustomResourceDefinition(item as V1CustomResourceDefinition);
                         break;
                     case WatchEventType.Deleted:
-                        container.Remove(item);
+                        items.Remove(item);
                         if (item is V1CustomResourceDefinition crd2)
                         {
                             RemoveCustomResourceDefinitionArtifacts(crd2);
@@ -1056,8 +1051,6 @@ public partial class ContainerClass<T> : ObservableObject, IClearableResourceCon
     public bool IsSeeded => InformerCount > 0;
 
     public ISourceCache<T, ResourceCacheKey> Items { get; } = new SourceCache<T, ResourceCacheKey>(ResourceCacheKey.From);
-
-    public void Remove(T resource) => Items.Remove(resource);
 
     public IObservable<ResourceChange> ConnectChanges(GroupApiVersionKind kind)
     {

--- a/src/KubeUI.Kubernetes/Client/Cluster.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.cs
@@ -412,7 +412,7 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
                         container.Items.AddOrUpdate(generic);
                         break;
                     case WatchEventType.Deleted:
-                        container.Items.Remove(generic);
+                        container.Remove(generic);
                         break;
                 }
 
@@ -474,19 +474,24 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
             var kind = GroupApiVersionKind.From<T>();
             ResourceInformerCallbackGuard.Execute(_logger, eventType, kind, item, () =>
             {
-                var items = GetResourceSourceCache<T>();
+                if (!Objects.TryGetValue(kind, out var objectContainer)
+                    || objectContainer is not ContainerClass<T> container)
+                {
+                    return;
+                }
+
                 switch (eventType)
                 {
                     case WatchEventType.Added:
-                        items.AddOrUpdate(item);
+                        container.Items.AddOrUpdate(item);
                         RegisterCustomResourceDefinition(item as V1CustomResourceDefinition);
                         break;
                     case WatchEventType.Modified:
-                        items.AddOrUpdate(item);
+                        container.Items.AddOrUpdate(item);
                         RegisterCustomResourceDefinition(item as V1CustomResourceDefinition);
                         break;
                     case WatchEventType.Deleted:
-                        items.Remove(item);
+                        container.Remove(item);
                         if (item is V1CustomResourceDefinition crd2)
                         {
                             RemoveCustomResourceDefinitionArtifacts(crd2);
@@ -1051,6 +1056,24 @@ public partial class ContainerClass<T> : ObservableObject, IClearableResourceCon
     public bool IsSeeded => InformerCount > 0;
 
     public ISourceCache<T, string> Items { get; } = new SourceCache<T, string>(GetResourceCacheKey);
+
+    public void Remove(T resource)
+    {
+        if (!string.IsNullOrEmpty(resource.Uid()))
+        {
+            Items.Remove(resource);
+            return;
+        }
+
+        var cachedResource = Items.Items.FirstOrDefault(item =>
+            string.Equals(item.Namespace(), resource.Namespace(), StringComparison.Ordinal)
+            && string.Equals(item.Name(), resource.Name(), StringComparison.Ordinal));
+
+        if (cachedResource != null)
+        {
+            Items.Remove(cachedResource);
+        }
+    }
 
     private static string GetResourceCacheKey(T resource)
     {

--- a/src/KubeUI.Kubernetes/Client/IClusterRuntime.cs
+++ b/src/KubeUI.Kubernetes/Client/IClusterRuntime.cs
@@ -34,10 +34,8 @@ public interface IClusterRuntime
     bool IsResourceNamespaced(GroupApiVersionKind kind);
     bool IsResourceNamespaced<T>();
     PortForwarder AddPodPortForward(string @namespace, string podName, int containerPort);
-    PortForwarder AddPodPortForward(string @namespace, string podName, string? podUid, int containerPort);
     Task AddPodEphemeralDebugContainer(V1Pod pod, string? targetContainerName, string image);
     PortForwarder AddServicePortForward(string @namespace, string serviceName, int servicePort);
-    PortForwarder AddServicePortForward(string @namespace, string serviceName, string? serviceUid, int servicePort);
     void RemovePortForward(PortForwarder pf);
     Task AddOrUpdateResource<T>(T item) where T : class, IKubernetesObject<V1ObjectMeta>, new();
     Task Connect();
@@ -52,8 +50,8 @@ public interface IClusterRuntime
     Task<bool> IsResourceReady<T>(CancellationToken? token = null) where T : class, IKubernetesObject<V1ObjectMeta>, new();
     T? GetResource<T>(string? @namespace, string name) where T : class, IKubernetesObject<V1ObjectMeta>, new();
     IReadOnlyList<T> GetResourceList<T>() where T : class, IKubernetesObject<V1ObjectMeta>, new();
-    ISourceCache<T, string> GetResourceSourceCache<T>() where T : class, IKubernetesObject<V1ObjectMeta>, new();
-    ISourceCache<T, string> GetResourceSourceCache<T>(GroupApiVersionKind kind) where T : class, IKubernetesObject<V1ObjectMeta>, new();
+    ISourceCache<T, ResourceCacheKey> GetResourceSourceCache<T>() where T : class, IKubernetesObject<V1ObjectMeta>, new();
+    ISourceCache<T, ResourceCacheKey> GetResourceSourceCache<T>(GroupApiVersionKind kind) where T : class, IKubernetesObject<V1ObjectMeta>, new();
     IObservable<int> GetResourceCount(GroupApiVersionKind kind);
     IObservable<int> GetResourceCount<T>() where T : class, IKubernetesObject<V1ObjectMeta>, new();
     IObservable<ResourceChange> ConnectResources() => ClusterResourceChangeFeed.Connect(this);

--- a/src/KubeUI.Kubernetes/Client/PortForwarder.cs
+++ b/src/KubeUI.Kubernetes/Client/PortForwarder.cs
@@ -20,8 +20,6 @@ public partial class PortForwarder : ObservableObject, IEquatable<PortForwarder>
 
     public int Port { get; private set; }
 
-    public string? ResourceUid { get; private set; }
-
     public string Type { get; private set; }
 
     [ObservableProperty]
@@ -52,26 +50,14 @@ public partial class PortForwarder : ObservableObject, IEquatable<PortForwarder>
 
     public void SetPod(string podName, int containerPort)
     {
-        SetPod(podName, null, containerPort);
-    }
-
-    public void SetPod(string podName, string? podUid, int containerPort)
-    {
         Name = podName;
-        ResourceUid = podUid;
         Port = containerPort;
         Type = "Pod";
     }
 
     public void SetService(string serviceName, int servicePort)
     {
-        SetService(serviceName, null, servicePort);
-    }
-
-    public void SetService(string serviceName, string? serviceUid, int servicePort)
-    {
         Name = serviceName;
-        ResourceUid = serviceUid;
         Port = servicePort;
         Type = "Service";
     }
@@ -178,33 +164,12 @@ public partial class PortForwarder : ObservableObject, IEquatable<PortForwarder>
         {
             var podName = Name;
             var podPort = Port;
-            if (Type == "Pod")
+            if (Type == "Service")
             {
-                if (ResourceUid is null)
-                {
-                    Status = "Pod UID is required";
-                    return;
-                }
-
-                var pod = _cluster.GetResourceSourceCache<V1Pod>().Lookup(ResourceUid!).ValueOrDefault();
-                if (pod is null)
-                {
-                    Status = "Pod not found";
-                    return;
-                }
-
-                podName = pod.Name();
-            }
-            else if (Type == "Service")
-            {
-                if (ResourceUid is null)
-                {
-                    Status = "Service UID is required";
-                    return;
-                }
-
-                var service = _cluster.GetResourceSourceCache<V1Service>().Lookup(ResourceUid!).ValueOrDefault();
-                if (service == null)
+                var service = _cluster.GetResourceSourceCache<V1Service>()
+                    .Lookup(new ResourceCacheKey(Namespace, Name))
+                    .ValueOrDefault();
+                if (service is null)
                 {
                     Status = "Service not found";
                     return;
@@ -232,28 +197,22 @@ public partial class PortForwarder : ObservableObject, IEquatable<PortForwarder>
                     return;
                 }
 
-                if (!TrySelectPod(endpointSlice, out var selectedPod, out var selectedPodUid))
+                if (!TrySelectPod(endpointSlice, out var selectedPod))
                 {
                     Status = "No pods found for Service";
                     return;
                 }
 
-                if (selectedPodUid is not null)
-                {
-                    var pod = _cluster.GetResourceSourceCache<V1Pod>().Lookup(selectedPodUid).ValueOrDefault();
-                    if (pod is null)
-                    {
-                        Status = "No pods found for Service";
-                        return;
-                    }
-
-                    podName = pod.Name();
-                }
-                else
+                var pod = _cluster.GetResourceSourceCache<V1Pod>()
+                    .Lookup(new ResourceCacheKey(Namespace, selectedPod))
+                    .ValueOrDefault();
+                if (pod is null)
                 {
                     Status = "No pods found for Service";
                     return;
                 }
+
+                podName = pod.Name();
                 podPort = (int)portData.Port;
             }
 
@@ -358,10 +317,9 @@ public partial class PortForwarder : ObservableObject, IEquatable<PortForwarder>
         return null;
     }
 
-    private static bool TrySelectPod(V1EndpointSlice endpointSlice, out string podName, out string? podUid)
+    private static bool TrySelectPod(V1EndpointSlice endpointSlice, out string podName)
     {
         podName = string.Empty;
-        podUid = null;
 
         var endpoints = endpointSlice.Endpoints;
         if (endpoints == null)
@@ -389,7 +347,6 @@ public partial class PortForwarder : ObservableObject, IEquatable<PortForwarder>
             if (Random.Shared.Next(eligiblePods) == 0)
             {
                 selectedPod = targetRef.Name;
-                podUid = targetRef.Uid;
             }
         }
 
@@ -488,8 +445,7 @@ public partial class PortForwarder : ObservableObject, IEquatable<PortForwarder>
             && other.Name == Name
             && other.Namespace == Namespace
             && other.Port == Port
-            && other.Type == Type
-            && other.ResourceUid == ResourceUid;
+            && other.Type == Type;
     }
 
     public void Dispose()

--- a/src/KubeUI.Kubernetes/Client/PortForwarder.cs
+++ b/src/KubeUI.Kubernetes/Client/PortForwarder.cs
@@ -203,16 +203,7 @@ public partial class PortForwarder : ObservableObject, IEquatable<PortForwarder>
                     return;
                 }
 
-                var pod = _cluster.GetResourceSourceCache<V1Pod>()
-                    .Lookup(new ResourceCacheKey(Namespace, selectedPod))
-                    .ValueOrDefault();
-                if (pod is null)
-                {
-                    Status = "No pods found for Service";
-                    return;
-                }
-
-                podName = pod.Name();
+                podName = selectedPod;
                 podPort = (int)portData.Port;
             }
 

--- a/src/KubeUI.Kubernetes/Client/ResourceCacheKey.cs
+++ b/src/KubeUI.Kubernetes/Client/ResourceCacheKey.cs
@@ -1,0 +1,23 @@
+using k8s;
+using k8s.Models;
+
+namespace KubeUI.Kubernetes;
+
+/// <summary>
+/// Identifies a Kubernetes resource by namespace and name without allocating a combined string key.
+/// </summary>
+/// <param name="Namespace">The resource namespace, or <see langword="null"/> for cluster-scoped resources.</param>
+/// <param name="Name">The resource name.</param>
+public readonly record struct ResourceCacheKey(string? Namespace, string Name)
+{
+    /// <summary>
+    /// Creates a cache key from a Kubernetes resource's namespace and name.
+    /// </summary>
+    /// <param name="resource">The resource to identify.</param>
+    /// <returns>An allocation-free namespace/name cache key.</returns>
+    public static ResourceCacheKey From(IKubernetesObject<V1ObjectMeta> resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        return new(resource.Metadata?.NamespaceProperty, resource.Metadata?.Name ?? string.Empty);
+    }
+}

--- a/src/KubeUI.Kubernetes/CustomSourceGenerationContext.cs
+++ b/src/KubeUI.Kubernetes/CustomSourceGenerationContext.cs
@@ -131,6 +131,8 @@ namespace KubeUI.Kubernetes;
 
 [JsonSerializable(typeof(V2beta1APIGroupDiscoveryList))]
 
+[JsonSerializable(typeof(Watcher<V1Status>.WatchEvent))]
+
 [JsonSourceGenerationOptions(
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,

--- a/tests/KubeUI.Avalonia.Tests/Features/Clusters/Workspace/ClusterWorkspaceTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Clusters/Workspace/ClusterWorkspaceTests.cs
@@ -156,8 +156,9 @@ public class ClusterWorkspaceTests
         var workspace = await Application.Current.CreateClusterAsync(
             config => config.Type = backend);
         await workspace.Runtime.SeedResource<V1CustomResourceDefinition>(true);
-        IResourceConfig? processedConfig = null;
-        workspace.ResourceConfigProcessed += (_, resourceConfig) => processedConfig = workspace.GetResourceConfig(resourceConfig.Kind);
+        System.Collections.Concurrent.ConcurrentQueue<IResourceConfig> processedConfigs = new();
+        workspace.ResourceConfigProcessed += (_, resourceConfig) =>
+            processedConfigs.Enqueue(workspace.GetResourceConfig(resourceConfig.Kind));
         var crd = ClusterWorkspaceTestCustomResourceDefinitionFactory.Create("tests.kubeui.com", "tests", "someString");
 
         await workspace.Runtime.CreateAsync(crd, TestContext.Current.CancellationToken);
@@ -167,7 +168,12 @@ public class ClusterWorkspaceTests
             TimeSpan.FromSeconds(10),
             cancellationToken: TestContext.Current.CancellationToken,
             beforePoll: () => Dispatcher.UIThread.RunJobs());
-        processedConfig.ShouldBeSameAs(resourceConfig);
+        await TestWait.UntilAsync(
+            () => processedConfigs.Count > 0,
+            TimeSpan.FromSeconds(10),
+            cancellationToken: TestContext.Current.CancellationToken,
+            beforePoll: () => Dispatcher.UIThread.RunJobs());
+        processedConfigs.ToArray().ShouldHaveSingleItem().ShouldBeSameAs(resourceConfig);
     }
 
     [AvaloniaTheory, KubernetesBackendData]

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/List/ResourceListViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/List/ResourceListViewModelTests.cs
@@ -94,11 +94,6 @@ public class ResourceListViewModelTests
 
     private static async Task AddOrUpdateAsync<T>(ClusterWorkspace cluster, T resource) where T : class, IKubernetesObject<V1ObjectMeta>, new()
     {
-        if (resource.Metadata.Uid is null)
-        {
-            resource.Metadata.Uid = cluster.Runtime.GetResource<T>(resource.Namespace(), resource.Name())?.Uid();
-        }
-
         await cluster.Runtime.AddOrUpdateResource(resource);
         await TestApplicationExtensions.WaitForUiAsync();
     }
@@ -757,11 +752,6 @@ public class ResourceListViewModelTests
         var baseTimestamp = DateTime.UtcNow.AddHours(-1);
         var events = Enumerable.Range(0, 400)
             .Select(index => Event("ns", $"event-{index:D3}", baseTimestamp.AddMinutes(index), index))
-            .Select(item =>
-            {
-                item.Metadata.Uid = item.Name();
-                return item;
-            })
             .ToArray();
 
         cluster.Runtime.GetResourceSourceCache<Corev1Event>().Edit(updater => updater.AddOrUpdate(events));
@@ -1052,11 +1042,6 @@ public class ResourceListViewModelTests
         var cluster = await Application.Current.CreateClusterAsync();
         var events = Enumerable.Range(0, 126)
             .Select(index => Event($"ns-{index % 3}", $"event-{index:D3}", DateTime.UtcNow.AddMinutes(index), index))
-            .Select(item =>
-            {
-                item.Metadata.Uid = item.Name();
-                return item;
-            })
             .ToArray();
 
         cluster.Runtime.GetResourceSourceCache<Corev1Event>().Edit(updater => updater.AddOrUpdate(events));
@@ -1092,11 +1077,6 @@ public class ResourceListViewModelTests
 
         var events = Enumerable.Range(0, 125)
             .Select(index => Event("default", $"event-{index}"))
-            .Select(item =>
-            {
-                item.Metadata.Uid = item.Name();
-                return item;
-            })
             .ToArray();
 
         await Task.Run(
@@ -2595,11 +2575,6 @@ public class ResourceListViewModelTests
                 "ns",
                 $"event-{index:D3}",
                 index < 50 ? now.AddMinutes(-1) : now.AddYears(-10)))
-            .Select(item =>
-            {
-                item.Metadata.Uid = item.Name();
-                return item;
-            })
             .ToArray();
         cluster.Runtime.GetResourceSourceCache<Corev1Event>().Edit(updater => updater.AddOrUpdate(events));
 

--- a/tests/KubeUI.Avalonia.Tests/Infrastructure/DataGrid/IdentityPreservingSelectionModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Infrastructure/DataGrid/IdentityPreservingSelectionModelTests.cs
@@ -1,5 +1,6 @@
 using k8s.Models;
 using KubeUI.Avalonia.Infrastructure.DataGrid;
+using KubeUI.Kubernetes;
 using Shouldly;
 
 namespace KubeUI.Avalonia.Tests.Infrastructure.DataGrid;
@@ -7,13 +8,13 @@ namespace KubeUI.Avalonia.Tests.Infrastructure.DataGrid;
 public sealed class IdentityPreservingSelectionModelTests
 {
     [Fact]
-    public void Restores_selection_by_uid_when_same_name_resources_reorder()
+    public void Restores_selection_by_namespace_and_name_when_resources_reorder()
     {
-        V1Pod first = Pod("uid-first");
-        V1Pod second = Pod("uid-second");
+        V1Pod first = Pod("namespace-a", "same-name");
+        V1Pod second = Pod("namespace-b", "same-name");
         List<V1Pod> source = [first, second];
 
-        using var model = new IdentityPreservingSelectionModel<V1Pod>(static pod => pod.Uid())
+        using var model = new IdentityPreservingSelectionModel<V1Pod, ResourceCacheKey>(ResourceCacheKey.From)
         {
             Source = source
         };
@@ -28,15 +29,14 @@ public sealed class IdentityPreservingSelectionModelTests
         model.SelectedItem.ShouldBe(first);
     }
 
-    private static V1Pod Pod(string uid)
+    private static V1Pod Pod(string @namespace, string name)
     {
         return new V1Pod
         {
             Metadata = new V1ObjectMeta
             {
-                NamespaceProperty = "default",
-                Name = "same-name",
-                Uid = uid,
+                NamespaceProperty = @namespace,
+                Name = name,
             },
         };
     }

--- a/tests/KubeUI.Kubernetes.Tests/Clients/ClusterResourceChangeFeedTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/Clients/ClusterResourceChangeFeedTests.cs
@@ -59,7 +59,6 @@ public sealed class ClusterResourceChangeFeedTests
             {
                 Name = secret.Name(),
                 NamespaceProperty = secret.Namespace(),
-                Uid = secret.Uid(),
                 ResourceVersion = secret.ResourceVersion(),
                 Labels = new Dictionary<string, string> { ["version"] = "two" },
             },

--- a/tests/KubeUI.Kubernetes.Tests/Clients/ContainerClassTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/Clients/ContainerClassTests.cs
@@ -9,49 +9,64 @@ namespace KubeUI.Kubernetes.Tests.Clients;
 public sealed class ContainerClassTests
 {
     [Fact]
-    public void Source_cache_uses_uid_for_resources_with_the_same_name()
+    public void SourceCacheUsesNamespaceAndNameAsResourceIdentity()
     {
-        ContainerClass<V1Pod> container = new();
-        V1Pod first = Pod("uid-first");
-        V1Pod second = Pod("uid-second");
+        var container = new ContainerClass<V1Pod>();
+        var first = Pod();
+        var second = Pod();
+        var otherNamespace = Pod("other");
 
         container.Items.Edit(updater => updater.AddOrUpdate(first));
         container.Items.Edit(updater => updater.AddOrUpdate(second));
+        container.Items.Edit(updater => updater.AddOrUpdate(otherNamespace));
 
         container.Items.Items.Count.ShouldBe(2);
-        container.Items.Lookup("uid-first").ValueOrDefault().ShouldBe(first);
-        container.Items.Lookup("uid-second").ValueOrDefault().ShouldBe(second);
+        container.Items.Lookup(new ResourceCacheKey("default", "same-name")).ValueOrDefault().ShouldBe(second);
+        container.Items.Lookup(new ResourceCacheKey("other", "same-name")).ValueOrDefault().ShouldBe(otherNamespace);
+        container.Items.Items.ShouldContain(second);
+        container.Items.Items.ShouldContain(otherNamespace);
     }
 
     [Fact]
-    public void Source_cache_removes_resource_when_delete_notification_has_no_uid()
+    public void SourceCacheAcceptsResourceWithoutUid()
     {
-        ContainerClass<V1Secret> container = new();
-        V1Secret existing = Secret("uid-existing");
-        V1Secret deleted = Secret(null);
+        var container = new ContainerClass<V1Secret>();
+        var resource = Secret();
+
+        var exception = Record.Exception(() => container.Items.AddOrUpdate(resource));
+
+        exception.ShouldBeNull();
+        container.Items.Items.ShouldContain(resource);
+    }
+
+    [Fact]
+    public void SourceCacheRemovesResourceWhenDeleteNotificationHasNoUid()
+    {
+        var container = new ContainerClass<V1Secret>();
+        var existing = Secret();
+        var deleted = Secret();
 
         container.Items.AddOrUpdate(existing);
 
-        Exception? exception = Record.Exception(() => container.Remove(deleted));
+        var exception = Record.Exception(() => container.Remove(deleted));
 
         exception.ShouldBeNull();
         container.Items.Items.ShouldBeEmpty();
     }
 
-    private static V1Pod Pod(string uid)
+    private static V1Pod Pod(string @namespace = "default")
     {
         return new V1Pod
         {
             Metadata = new V1ObjectMeta
             {
-                NamespaceProperty = "default",
+                NamespaceProperty = @namespace,
                 Name = "same-name",
-                Uid = uid,
             },
         };
     }
 
-    private static V1Secret Secret(string? uid)
+    private static V1Secret Secret()
     {
         return new V1Secret
         {
@@ -59,7 +74,6 @@ public sealed class ContainerClassTests
             {
                 NamespaceProperty = "kube-system",
                 Name = "same-name",
-                Uid = uid,
             },
         };
     }

--- a/tests/KubeUI.Kubernetes.Tests/Clients/ContainerClassTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/Clients/ContainerClassTests.cs
@@ -23,6 +23,21 @@ public sealed class ContainerClassTests
         container.Items.Lookup("uid-second").ValueOrDefault().ShouldBe(second);
     }
 
+    [Fact]
+    public void Source_cache_removes_resource_when_delete_notification_has_no_uid()
+    {
+        ContainerClass<V1Secret> container = new();
+        V1Secret existing = Secret("uid-existing");
+        V1Secret deleted = Secret(null);
+
+        container.Items.AddOrUpdate(existing);
+
+        Exception? exception = Record.Exception(() => container.Remove(deleted));
+
+        exception.ShouldBeNull();
+        container.Items.Items.ShouldBeEmpty();
+    }
+
     private static V1Pod Pod(string uid)
     {
         return new V1Pod
@@ -30,6 +45,19 @@ public sealed class ContainerClassTests
             Metadata = new V1ObjectMeta
             {
                 NamespaceProperty = "default",
+                Name = "same-name",
+                Uid = uid,
+            },
+        };
+    }
+
+    private static V1Secret Secret(string? uid)
+    {
+        return new V1Secret
+        {
+            Metadata = new V1ObjectMeta
+            {
+                NamespaceProperty = "kube-system",
                 Name = "same-name",
                 Uid = uid,
             },

--- a/tests/KubeUI.Kubernetes.Tests/Clients/ContainerClassTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/Clients/ContainerClassTests.cs
@@ -48,7 +48,7 @@ public sealed class ContainerClassTests
 
         container.Items.AddOrUpdate(existing);
 
-        var exception = Record.Exception(() => container.Remove(deleted));
+        var exception = Record.Exception(() => container.Items.Remove(deleted));
 
         exception.ShouldBeNull();
         container.Items.Items.ShouldBeEmpty();

--- a/tests/KubeUI.Kubernetes.Tests/PortForwarderTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/PortForwarderTests.cs
@@ -338,6 +338,92 @@ public sealed class PortForwarderTests
         await WaitForAsync(() => sut.Connections == 0, cancellationToken: TestContext.Current.CancellationToken);
     }
 
+    [Theory, KubernetesBackendData]
+    [Trait("Category", "Kind")]
+    public async Task Service_forward_uses_ready_endpoint_pod_without_pod_cache(KubernetesBackend backend)
+    {
+        await using var harness = await new TestClusterGenerator().CreateAsync(
+            new TestClusterConfig { Type = backend },
+            TestContext.Current.CancellationToken);
+        var cluster = harness.Cluster;
+        await cluster.Connect();
+        await cluster.Permissions.UpdatePermissionsAllNamespaceAsync<V1Service>(Verb.List);
+        await cluster.Permissions.UpdatePermissionsAllNamespaceAsync<V1Service>(Verb.Watch);
+        await cluster.Permissions.UpdatePermissionsAllNamespaceAsync<V1EndpointSlice>(Verb.List);
+        await cluster.Permissions.UpdatePermissionsAllNamespaceAsync<V1EndpointSlice>(Verb.Watch);
+        await cluster.SeedResource<V1Service>(true);
+        await cluster.SeedResource<V1EndpointSlice>(true);
+        await cluster.AddOrUpdateResource(CreateService());
+        await cluster.AddOrUpdateResource(new V1EndpointSlice
+        {
+            AddressType = "IPv4",
+            Metadata = new V1ObjectMeta
+            {
+                Name = "prometheus-slice",
+                NamespaceProperty = "default",
+                Labels = new Dictionary<string, string>
+                {
+                    ["kubernetes.io/service-name"] = "prometheus",
+                },
+            },
+            Ports =
+            [
+                new Discoveryv1EndpointPort
+                {
+                    Name = "http",
+                    Port = 9090,
+                },
+            ],
+            Endpoints =
+            [
+                new V1Endpoint
+                {
+                    Addresses = ["192.0.2.1"],
+                    Conditions = new V1EndpointConditions
+                    {
+                        Ready = true,
+                        Serving = true,
+                    },
+                    TargetRef = new V1ObjectReference
+                    {
+                        Kind = "Pod",
+                        Name = "prometheus-0",
+                        NamespaceProperty = "default",
+                    },
+                },
+            ],
+        });
+        await ClusterScenarioAssertions.WaitForResourceAsync<V1Service>(
+            cluster,
+            "default",
+            "prometheus",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await ClusterScenarioAssertions.WaitForResourceAsync<V1EndpointSlice>(
+            cluster,
+            "default",
+            "prometheus-slice",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        using var stream = new CaptureStream();
+        var session = new Mock<IPortForwardSession>(MockBehavior.Strict);
+        session.SetupGet(x => x.Stream).Returns(stream);
+        session.Setup(x => x.Dispose());
+
+        var factory = new Mock<IPortForwardSessionFactory>(MockBehavior.Strict);
+        factory.Setup(x => x.CreateAsync("prometheus-0", "default", 9090)).ReturnsAsync(session.Object);
+
+        using var sut = new PortForwarder(cluster, "default", localPort: 0, sessionFactory: factory.Object);
+        sut.SetService("prometheus", 9090);
+        sut.Start();
+
+        await ConnectAsync(sut.LocalPort, TestContext.Current.CancellationToken);
+
+        await WaitForAsync(
+            () => factory.Invocations.Any(invocation => invocation.Method.Name == nameof(IPortForwardSessionFactory.CreateAsync)),
+            cancellationToken: TestContext.Current.CancellationToken);
+        factory.Verify(x => x.CreateAsync("prometheus-0", "default", 9090), Times.Once);
+    }
+
     private static V1Service CreateService()
     {
         return new V1Service

--- a/tests/KubeUI.Kubernetes.Tests/PortForwarderTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/PortForwarderTests.cs
@@ -156,7 +156,6 @@ public sealed class PortForwarderTests
             {
                 Name = "pod-1",
                 NamespaceProperty = "default",
-                Uid = "pod-uid",
             },
         }));
         using var stream = new CaptureStream();
@@ -168,7 +167,7 @@ public sealed class PortForwarderTests
         factory.Setup(x => x.CreateAsync("pod-1", "default", 8080)).ReturnsAsync(session.Object);
 
         using var sut = new PortForwarder(cluster, "default", localPort: 0, sessionFactory: factory.Object);
-        sut.SetPod("pod-1", "pod-uid", 8080);
+        sut.SetPod("pod-1", 8080);
         sut.Start();
 
         var payload = Encoding.UTF8.GetBytes("ping");
@@ -208,10 +207,8 @@ public sealed class PortForwarderTests
             "default",
             "prometheus",
             cancellationToken: TestContext.Current.CancellationToken);
-        var serviceUid = cluster.GetResource<V1Service>("default", "prometheus")!.Uid();
-
         using var sut = new PortForwarder(cluster, "default");
-        sut.SetService("prometheus", serviceUid!, 9090);
+        sut.SetService("prometheus", 9090);
         sut.Start();
 
         await ConnectAsync(sut.LocalPort, TestContext.Current.CancellationToken);
@@ -262,10 +259,8 @@ public sealed class PortForwarderTests
             "default",
             "prometheus-slice",
             cancellationToken: TestContext.Current.CancellationToken);
-        var serviceUid = cluster.GetResource<V1Service>("default", "prometheus")!.Uid();
-
         using var sut = new PortForwarder(cluster, "default");
-        sut.SetService("prometheus", serviceUid!, 9090);
+        sut.SetService("prometheus", 9090);
         sut.Start();
 
         await ConnectAsync(sut.LocalPort, TestContext.Current.CancellationToken);
@@ -324,7 +319,6 @@ public sealed class PortForwarderTests
                     {
                         Kind = "Pod",
                         Name = "prometheus-0",
-                        Uid = "prometheus-0-uid",
                     },
                 },
             ],
@@ -334,10 +328,8 @@ public sealed class PortForwarderTests
             "default",
             "prometheus-slice",
             cancellationToken: TestContext.Current.CancellationToken);
-        var serviceUid = cluster.GetResource<V1Service>("default", "prometheus")!.Uid();
-
         using var sut = new PortForwarder(cluster, "default");
-        sut.SetService("prometheus", serviceUid!, 9090);
+        sut.SetService("prometheus", 9090);
         sut.Start();
 
         await ConnectAsync(sut.LocalPort, TestContext.Current.CancellationToken);

--- a/tests/KubeUI.Kubernetes.Tests/Resources/PortForwarding/PortForwarderTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/Resources/PortForwarding/PortForwarderTests.cs
@@ -157,7 +157,6 @@ public sealed class PortForwarderTests
             {
                 Name = "pod-1",
                 NamespaceProperty = "default",
-                Uid = "pod-uid",
             },
         }));
         using var stream = new CaptureStream();
@@ -169,7 +168,7 @@ public sealed class PortForwarderTests
         factory.Setup(x => x.CreateAsync("pod-1", "default", 8080)).ReturnsAsync(session.Object);
 
         using var sut = new PortForwarder(cluster, "default", localPort: 0, sessionFactory: factory.Object);
-        sut.SetPod("pod-1", "pod-uid", 8080);
+        sut.SetPod("pod-1", 8080);
         sut.Start();
 
         var payload = Encoding.UTF8.GetBytes("ping");
@@ -187,49 +186,6 @@ public sealed class PortForwarderTests
         factory.Verify(x => x.CreateAsync("pod-1", "default", 8080), Times.Once);
         session.VerifyGet(x => x.Stream, Times.AtLeastOnce);
         stream.WrittenBytes.ShouldBe(payload);
-    }
-
-    [Fact]
-    public async Task Pod_forward_resolves_current_pod_name_by_uid()
-    {
-        await using var harness = await new TestClusterGenerator().CreateAsync(new TestClusterConfig(), TestContext.Current.CancellationToken);
-        var cluster = harness.Cluster;
-        await cluster.Connect();
-        await cluster.SeedResource<V1Pod>(true);
-
-        cluster.GetResourceSourceCache<V1Pod>().Edit(updater => updater.AddOrUpdate(new V1Pod
-        {
-            Metadata = new V1ObjectMeta
-            {
-                Name = "current-pod-name",
-                NamespaceProperty = "default",
-                Uid = "pod-uid",
-            },
-        }));
-
-        using var stream = new CaptureStream();
-        var session = new Mock<IPortForwardSession>(MockBehavior.Strict);
-        session.SetupGet(x => x.Stream).Returns(stream);
-        session.Setup(x => x.Dispose());
-
-        var factory = new Mock<IPortForwardSessionFactory>(MockBehavior.Strict);
-        factory.Setup(x => x.CreateAsync("current-pod-name", "default", 8080)).ReturnsAsync(session.Object);
-
-        using var sut = new PortForwarder(cluster, "default", localPort: 0, sessionFactory: factory.Object);
-        sut.SetPod("stale-pod-name", "pod-uid", 8080);
-        sut.Start();
-
-        using (var client = new TcpClient())
-        {
-            await client.ConnectAsync(IPAddress.Loopback, sut.LocalPort, TestContext.Current.CancellationToken);
-            client.Client.Shutdown(SocketShutdown.Send);
-        }
-
-        await WaitForAsync(() => sut.Connections == 0, cancellationToken: TestContext.Current.CancellationToken);
-        await WaitForAsync(
-            () => factory.Invocations.Any(invocation => invocation.Method.Name == nameof(IPortForwardSessionFactory.CreateAsync)),
-            cancellationToken: TestContext.Current.CancellationToken);
-        factory.Verify(x => x.CreateAsync("current-pod-name", "default", 8080), Times.Once);
     }
 
     [Theory, KubernetesBackendData]
@@ -252,10 +208,8 @@ public sealed class PortForwarderTests
             "default",
             "prometheus",
             cancellationToken: TestContext.Current.CancellationToken);
-        var serviceUid = cluster.GetResource<V1Service>("default", "prometheus")!.Uid();
-
         using var sut = new PortForwarder(cluster, "default");
-        sut.SetService("prometheus", serviceUid!, 9090);
+        sut.SetService("prometheus", 9090);
         sut.Start();
 
         await ConnectAsync(sut.LocalPort, TestContext.Current.CancellationToken);
@@ -306,10 +260,8 @@ public sealed class PortForwarderTests
             "default",
             "prometheus-slice",
             cancellationToken: TestContext.Current.CancellationToken);
-        var serviceUid = cluster.GetResource<V1Service>("default", "prometheus")!.Uid();
-
         using var sut = new PortForwarder(cluster, "default");
-        sut.SetService("prometheus", serviceUid!, 9090);
+        sut.SetService("prometheus", 9090);
         sut.Start();
 
         await ConnectAsync(sut.LocalPort, TestContext.Current.CancellationToken);
@@ -368,7 +320,6 @@ public sealed class PortForwarderTests
                     {
                         Kind = "Pod",
                         Name = "prometheus-0",
-                        Uid = "prometheus-0-uid",
                     },
                 },
             ],
@@ -378,10 +329,8 @@ public sealed class PortForwarderTests
             "default",
             "prometheus-slice",
             cancellationToken: TestContext.Current.CancellationToken);
-        var serviceUid = cluster.GetResource<V1Service>("default", "prometheus")!.Uid();
-
         using var sut = new PortForwarder(cluster, "default");
-        sut.SetService("prometheus", serviceUid!, 9090);
+        sut.SetService("prometheus", 9090);
         sut.Start();
 
         await ConnectAsync(sut.LocalPort, TestContext.Current.CancellationToken);

--- a/tests/KubeUI.Kubernetes.Tests/Resources/PortForwarding/PortForwarderTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/Resources/PortForwarding/PortForwarderTests.cs
@@ -339,6 +339,92 @@ public sealed class PortForwarderTests
         await WaitForAsync(() => sut.Connections == 0, cancellationToken: TestContext.Current.CancellationToken);
     }
 
+    [Theory, KubernetesBackendData]
+    [Trait("Category", "Kind")]
+    public async Task Service_forward_uses_ready_endpoint_pod_without_pod_cache(KubernetesBackend backend)
+    {
+        await using var harness = await new TestClusterGenerator().CreateAsync(
+            new TestClusterConfig { Type = backend },
+            TestContext.Current.CancellationToken);
+        var cluster = harness.Cluster;
+        await cluster.Connect();
+        await cluster.Permissions.UpdatePermissionsAllNamespaceAsync<V1Service>(Verb.List);
+        await cluster.Permissions.UpdatePermissionsAllNamespaceAsync<V1Service>(Verb.Watch);
+        await cluster.Permissions.UpdatePermissionsAllNamespaceAsync<V1EndpointSlice>(Verb.List);
+        await cluster.Permissions.UpdatePermissionsAllNamespaceAsync<V1EndpointSlice>(Verb.Watch);
+        await cluster.SeedResource<V1Service>(true);
+        await cluster.SeedResource<V1EndpointSlice>(true);
+        await cluster.AddOrUpdateResource(CreateService());
+        await cluster.AddOrUpdateResource(new V1EndpointSlice
+        {
+            AddressType = "IPv4",
+            Metadata = new V1ObjectMeta
+            {
+                Name = "prometheus-slice",
+                NamespaceProperty = "default",
+                Labels = new Dictionary<string, string>
+                {
+                    ["kubernetes.io/service-name"] = "prometheus",
+                },
+            },
+            Ports =
+            [
+                new Discoveryv1EndpointPort
+                {
+                    Name = "http",
+                    Port = 9090,
+                },
+            ],
+            Endpoints =
+            [
+                new V1Endpoint
+                {
+                    Addresses = ["192.0.2.1"],
+                    Conditions = new V1EndpointConditions
+                    {
+                        Ready = true,
+                        Serving = true,
+                    },
+                    TargetRef = new V1ObjectReference
+                    {
+                        Kind = "Pod",
+                        Name = "prometheus-0",
+                        NamespaceProperty = "default",
+                    },
+                },
+            ],
+        });
+        await ClusterRuntimeAssertions.WaitForResourceAsync<V1Service>(
+            cluster,
+            "default",
+            "prometheus",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await ClusterRuntimeAssertions.WaitForResourceAsync<V1EndpointSlice>(
+            cluster,
+            "default",
+            "prometheus-slice",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        using var stream = new CaptureStream();
+        var session = new Mock<IPortForwardSession>(MockBehavior.Strict);
+        session.SetupGet(x => x.Stream).Returns(stream);
+        session.Setup(x => x.Dispose());
+
+        var factory = new Mock<IPortForwardSessionFactory>(MockBehavior.Strict);
+        factory.Setup(x => x.CreateAsync("prometheus-0", "default", 9090)).ReturnsAsync(session.Object);
+
+        using var sut = new PortForwarder(cluster, "default", localPort: 0, sessionFactory: factory.Object);
+        sut.SetService("prometheus", 9090);
+        sut.Start();
+
+        await ConnectAsync(sut.LocalPort, TestContext.Current.CancellationToken);
+
+        await WaitForAsync(
+            () => factory.Invocations.Any(invocation => invocation.Method.Name == nameof(IPortForwardSessionFactory.CreateAsync)),
+            cancellationToken: TestContext.Current.CancellationToken);
+        factory.Verify(x => x.CreateAsync("prometheus-0", "default", 9090), Times.Once);
+    }
+
     private static V1Service CreateService()
     {
         return new V1Service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resources are now identified by namespace and name, including resources without UID metadata.
  * Added reliable selection restoration for same-named resources in different namespaces.
  * Service port forwarding now resolves ready endpoint pods directly, even when they are not cached.
* **Bug Fixes**
  * Improved resource cache updates and deletion handling when UID information is unavailable.
  * Simplified pod and service port forwarding target resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->