### PR TITLE
chore: fix CI failures on beta branch due to concurrency issues

### DIFF
--- a/src/KubeUI.Kubernetes/Client/Cluster.Auth.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.Auth.cs
@@ -120,14 +120,6 @@ public partial class Cluster
 
     private IReadOnlyCollection<string> GetKnownNamespaceNames()
     {
-        if (Namespaces is { Count: > 0 })
-        {
-            return Namespaces
-                .Select(static item => item.Name())
-                .Where(static name => !string.IsNullOrWhiteSpace(name))
-                .ToArray();
-        }
-
         if (Objects.TryGetValue(GroupApiVersionKind.From<V1Namespace>(), out var container)
             && container is ContainerClass<V1Namespace> namespaceContainer)
         {

--- a/tests/KubeUI.Avalonia.Tests/Features/Clusters/Workspace/ClusterWorkspaceTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Clusters/Workspace/ClusterWorkspaceTests.cs
@@ -156,8 +156,15 @@ public class ClusterWorkspaceTests
         var workspace = await Application.Current.CreateClusterAsync(
             config => config.Type = backend);
         await workspace.Runtime.SeedResource<V1CustomResourceDefinition>(true);
-        IResourceConfig? processedConfig = null;
-        workspace.ResourceConfigProcessed += (_, resourceConfig) => processedConfig = workspace.GetResourceConfig(resourceConfig.Kind);
+        TaskCompletionSource<IResourceConfig> processedConfig =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        workspace.ResourceConfigProcessed += (_, resourceConfig) =>
+        {
+            if (resourceConfig.IsCustomResource)
+            {
+                processedConfig.TrySetResult(workspace.GetResourceConfig(resourceConfig.Kind));
+            }
+        };
         var crd = ClusterWorkspaceTestCustomResourceDefinitionFactory.Create("tests.kubeui.com", "tests", "someString");
 
         await workspace.Runtime.CreateAsync(crd, TestContext.Current.CancellationToken);
@@ -167,7 +174,8 @@ public class ClusterWorkspaceTests
             TimeSpan.FromSeconds(10),
             cancellationToken: TestContext.Current.CancellationToken,
             beforePoll: () => Dispatcher.UIThread.RunJobs());
-        processedConfig.ShouldBeSameAs(resourceConfig);
+        var observedConfig = await processedConfig.Task.WaitAsync(TestContext.Current.CancellationToken);
+        observedConfig.ShouldBeSameAs(resourceConfig);
     }
 
     [AvaloniaTheory, KubernetesBackendData]


### PR DESCRIPTION
This pull request addresses two concurrency-related failures that caused the CI to fail on the beta branch. The changes made include:

- **Cluster.Auth.cs**: Updated the namespace enumeration to use a thread-safe source-cache snapshot instead of the UI-bound observable collection, preventing concurrent access issues.
- **ClusterWorkspaceTests.cs**: Modified the CRD event test to explicitly await the expected event, eliminating a race condition.

Validation steps confirmed that the release build succeeded with no errors and all tests passed (806/806). This ensures that the identified issues are resolved and the CI process is stable.