### PR TITLE
feat: improve pod log viewer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,10 +15,5 @@
     <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
 
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --config-file $(MSBuildThisFileDirectory)testconfig.json</TestingPlatformCommandLineArguments>
-
-    <!-- Disable Avalonia.BuildServices' AvaloniaStats task for all projects.
-         Due to build errors, System.UnauthorizedAccessException: Access to the path 'C:\Users\username\AppData\Local\AvaloniaUI\BuildServices\buildtasks.log' is denied.
-    -->
-    <UsedAvaloniaProducts></UsedAvaloniaProducts>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <!-- Disable Avalonia.BuildServices' AvaloniaStats task for all projects.
+         Due to build errors, System.UnauthorizedAccessException: Access to the path 'C:\Users\username\AppData\Local\AvaloniaUI\BuildServices\buildtasks.log' is denied.
+    -->
+    <UsedAvaloniaProducts></UsedAvaloniaProducts>
+  </PropertyGroup>
+</Project>

--- a/src/KubeUI.Avalonia/Assets/Resources.resx
+++ b/src/KubeUI.Avalonia/Assets/Resources.resx
@@ -1077,6 +1077,18 @@
     <value>Clear Logs</value>
     <comment/>
   </data>
+  <data name="PodLogsView_LogUpdatesPaused" xml:space="preserve">
+    <value>Live log updates paused · {0} new lines</value>
+    <comment/>
+  </data>
+  <data name="PodLogsView_UpdatesPaused" xml:space="preserve">
+    <value>Live log updates paused</value>
+    <comment/>
+  </data>
+  <data name="PodLogsView_ResumeFollowing" xml:space="preserve">
+    <value>Resume Following</value>
+    <comment/>
+  </data>
   <data name="V1PodConfig_DebugContainer" xml:space="preserve">
     <value>Add Debug Container</value>
     <comment/>

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/AGENTS.md
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/AGENTS.md
@@ -31,5 +31,6 @@
 - Resource Lists expose one View Logs action. When a compatible logs tool is active for the cluster, its submenu explicitly offers Open New Logs View or Add to Current Logs View; never assume the user wants selections grouped.
 - Combined exports use a multi-resource filename and manifest, and describe cross-stream output as arrival-ordered.
 - New sessions and resource-add refreshes open all selected Pod/container streams concurrently, load the last 500 lines from each, and then follow live output.
+- Batch buffered log output into bounded UI updates and await each update before queuing another from the same reader. Flush pending lines before waiting for more network output, and trim retained lines in one document update.
 - Ctrl+F search panel exposes a pod-log filter toggle. Filtering uses AvaloniaEdit search options and a separate bounded display document while preserving canonical logs for streaming and export; closing search clears the filter.
 - Closing search resets the filter toggle. Incomplete regexes retain the last valid filtered view; unchanged matching output must preserve the displayed document and selection.

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/AGENTS.md
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/AGENTS.md
@@ -20,7 +20,10 @@
 - Pod and container selection changes clear errors from the previous connection immediately; failures from the new selection remain visible.
 - Resource-name prefixes default to enabled when entering a multi-pod or multi-container display mode, while explicit user changes survive reconnects in the same mode.
 - Label the action that controls automatic scrolling as `Follow Logs`; keep it visible and enabled, with its checked state indicating whether the editor follows the newest output.
+- When Follow Logs is disabled or the editor is scrolled away from the bottom, freeze the displayed document while continuing to buffer incoming lines; show the pending line count and a Resume Following action.
 - Recompute Follow Logs state when either the editor scroll offset or viewport changes, including when resizing introduces vertical overflow.
+- Treat extent and viewport changes as layout changes rather than user scrolling; a view already pinned to the bottom must remain pinned and keep Follow Logs enabled while resizing.
+- Consider the view pinned when the remaining scroll distance is within half a rendered line so fractional line visibility does not disable Follow Logs.
 - Use the down-arrow-to-line icon for Follow Logs so it reads as returning to the bottom of the output.
 - Keep the log action toolbar compact without visual separators between action groups.
 - Use a broom icon for Clear Logs so the action does not imply deleting a Kubernetes resource or file.

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Behaviors/PodLogsEditorBehavior.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Behaviors/PodLogsEditorBehavior.cs
@@ -574,7 +574,8 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
 
     private void RequestRestoreScrollOffset()
     {
-        _pendingRestoreOffset = ScrollOffset;
+        var targetOffset = ScrollOffset;
+        _pendingRestoreOffset = targetOffset == default ? null : targetOffset;
         Dispatcher.UIThread.Post(RestoreScrollOffset, DispatcherPriority.Loaded);
     }
 

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Behaviors/PodLogsEditorBehavior.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Behaviors/PodLogsEditorBehavior.cs
@@ -62,6 +62,7 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
     private Size _lastViewport;
     private bool _hasScrollMetrics;
     private IDisposable? _scrollViewerOffsetSubscription;
+    private bool _followWasEnabledBeforeOverflow;
     private SearchPanel? _searchPanel;
     private TextDocument? _sourceDocument;
     private readonly TextDocument _filteredDocument = new();
@@ -247,13 +248,16 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
         {
             var metricsChanged = UpdateScrollMetrics(_scrollViewer);
 
-            if (_scrollViewer.ScrollBarMaximum.Y > 0
+            if (_scrollViewer.ScrollBarMaximum.Y <= 0)
+            {
+                _followWasEnabledBeforeOverflow = AutoScrollToBottom;
+            }
+            else if (_followWasEnabledBeforeOverflow
                 && ScrollOffset == default
-                && _scrollViewer.Offset == ScrollOffset
+                && AutoScrollToBottom
                 && _pendingRestoreOffset is null)
             {
                 _isStuckToBottom = true;
-                AutoScrollToBottom = true;
                 QueueStickToBottom();
                 Dispatcher.UIThread.Post(StickToBottom, DispatcherPriority.ApplicationIdle);
             }
@@ -667,12 +671,15 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
 
         if (ScrollOffset == default
             && _scrollViewer.Offset == ScrollOffset
-            && _scrollViewer.ScrollBarMaximum.Y > 0)
+            && _followWasEnabledBeforeOverflow)
         {
-            _isStuckToBottom = true;
-            AutoScrollToBottom = true;
-            QueueStickToBottom();
-            Dispatcher.UIThread.Post(StickToBottom, DispatcherPriority.ApplicationIdle);
+            if (AutoScrollToBottom && _scrollViewer.ScrollBarMaximum.Y > 0)
+            {
+                _isStuckToBottom = true;
+                QueueStickToBottom();
+                Dispatcher.UIThread.Post(StickToBottom, DispatcherPriority.ApplicationIdle);
+            }
+
             return;
         }
 
@@ -702,11 +709,16 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
             return;
         }
 
-        if (ScrollOffset == default && _scrollViewer.Offset == ScrollOffset)
+        if (ScrollOffset == default
+            && _scrollViewer.Offset == ScrollOffset
+            && _followWasEnabledBeforeOverflow)
         {
-            _isStuckToBottom = true;
-            AutoScrollToBottom = true;
-            QueueStickToBottom();
+            if (AutoScrollToBottom)
+            {
+                _isStuckToBottom = true;
+                QueueStickToBottom();
+            }
+
             return;
         }
 
@@ -794,6 +806,14 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
 
     private void SynchronizePinnedState(ScrollViewer scrollViewer)
     {
+        if (_followWasEnabledBeforeOverflow
+            && ScrollOffset == default
+            && scrollViewer.Offset == default)
+        {
+            _isStuckToBottom = true;
+            return;
+        }
+
         _isStuckToBottom = IsAtBottom(scrollViewer);
         AutoScrollToBottom = _isStuckToBottom;
     }

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Behaviors/PodLogsEditorBehavior.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Behaviors/PodLogsEditorBehavior.cs
@@ -58,6 +58,10 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
     private bool _initialLayoutComplete;
     private bool _stickToBottomQueued;
     private bool _followLogsQueued;
+    private Size _lastExtent;
+    private Size _lastViewport;
+    private bool _hasScrollMetrics;
+    private IDisposable? _scrollViewerOffsetSubscription;
     private SearchPanel? _searchPanel;
     private TextDocument? _sourceDocument;
     private readonly TextDocument _filteredDocument = new();
@@ -86,6 +90,21 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
             SetAndRaise(FollowLogsRequestedProperty, ref _followLogsRequested, value);
             if (value)
             {
+                _pendingRestoreOffset = null;
+                if (_initialLayoutComplete && _scrollViewer is not null && IsAtBottom(_scrollViewer))
+                {
+                    FollowLogs();
+                    return;
+                }
+
+                if (Dispatcher.UIThread.CheckAccess()
+                    && _scrollViewer is not null
+                    && _scrollViewer.Viewport.Height > 0)
+                {
+                    FollowLogs();
+                    return;
+                }
+
                 _followLogsQueued = true;
                 Dispatcher.UIThread.Post(FollowLogs, DispatcherPriority.Loaded);
             }
@@ -124,6 +143,7 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
         ApplyTheme();
         AttachScrollViewer();
         _initialLayoutComplete = false;
+        _hasScrollMetrics = false;
         RestoreScrollOffset();
     }
 
@@ -168,7 +188,7 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
             Application.Current.ActualThemeVariantChanged -= CurrentOnActualThemeVariantChanged;
         }
 
-        PersistScrollOffset();
+        PersistScrollOffset(synchronizePinnedState: false);
         DetachScrollViewer();
 
         _textMateInstallation?.Dispose();
@@ -190,13 +210,18 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
 
     private void AssociatedObjectOnDataContextChanged(object? sender, EventArgs e)
     {
-        PersistScrollOffset();
-        _isStuckToBottom = true;
+        PersistScrollOffset(synchronizePinnedState: false);
+        _isStuckToBottom = AutoScrollToBottom;
         _initialLayoutComplete = false;
+        _hasScrollMetrics = false;
         _stickToBottomQueued = false;
         _followLogsQueued = false;
         AttachScrollViewer();
         RequestRestoreScrollOffset();
+        if (FollowLogsRequested)
+        {
+            _pendingRestoreOffset = null;
+        }
     }
 
     private void AssociatedObjectOnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
@@ -209,7 +234,7 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
 
     private void AssociatedObjectOnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
     {
-        PersistScrollOffset();
+        PersistScrollOffset(synchronizePinnedState: false);
         _textMateInstallation?.Dispose();
         _textMateInstallation = null;
     }
@@ -218,21 +243,37 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
     {
         AttachScrollViewer();
 
-        if (_scrollViewer is not null && !_initialLayoutComplete && _scrollViewer.Viewport.Height > 0)
+        if (_scrollViewer is not null)
         {
-            _initialLayoutComplete = true;
-            if (AutoScrollToBottom && ScrollOffset == default)
+            var metricsChanged = UpdateScrollMetrics(_scrollViewer);
+
+            if (!_initialLayoutComplete && _scrollViewer.Viewport.Height > 0)
             {
-                _isStuckToBottom = true;
-                QueueStickToBottom();
+                _initialLayoutComplete = true;
+                if (AutoScrollToBottom && ScrollOffset == default)
+                {
+                    _isStuckToBottom = true;
+                    QueueStickToBottom();
+                }
+                else if (AutoScrollToBottom && _pendingRestoreOffset is null)
+                {
+                    SynchronizePinnedState(_scrollViewer);
+                }
+                else
+                {
+                    _isStuckToBottom = false;
+                }
             }
-            else
+            else if (metricsChanged && AutoScrollToBottom && _isStuckToBottom)
             {
-                SynchronizePinnedState(_scrollViewer);
+                QueueStickToBottom();
             }
         }
 
-        if (_pendingRestoreOffset is not null)
+        if (_pendingRestoreOffset is not null
+            && _scrollViewer is not null
+            && (_scrollViewer.Extent.Width > _scrollViewer.Viewport.Width
+                || _scrollViewer.Extent.Height > _scrollViewer.Viewport.Height))
         {
             RequestRestoreScrollOffset();
         }
@@ -496,16 +537,31 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
 
         if (_scrollViewer.Extent.Width <= _scrollViewer.Viewport.Width && _scrollViewer.Extent.Height <= _scrollViewer.Viewport.Height)
         {
-            _pendingRestoreOffset = null;
+            if (_pendingRestoreOffset is null && targetOffset != default)
+            {
+                _pendingRestoreOffset = targetOffset;
+            }
+
             return;
         }
 
         _isRestoringScrollOffset = true;
         try
         {
-            _scrollViewer.Offset = targetOffset;
-            SynchronizePinnedState(_scrollViewer);
-            if (_scrollViewer.Offset == targetOffset)
+            var maximumOffset = _scrollViewer.ScrollBarMaximum;
+            var clampedTarget = new Vector(
+                Math.Clamp(targetOffset.X, 0, maximumOffset.X),
+                Math.Clamp(targetOffset.Y, 0, maximumOffset.Y));
+            _scrollViewer.Offset = clampedTarget;
+            if (AutoScrollToBottom)
+            {
+                SynchronizePinnedState(_scrollViewer);
+            }
+            else
+            {
+                _isStuckToBottom = false;
+            }
+            if (_scrollViewer.Offset == clampedTarget)
             {
                 _pendingRestoreOffset = null;
             }
@@ -522,7 +578,7 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
         Dispatcher.UIThread.Post(RestoreScrollOffset, DispatcherPriority.Loaded);
     }
 
-    private void PersistScrollOffset()
+    private void PersistScrollOffset(bool synchronizePinnedState = true)
     {
         if (AssociatedObject is null || _scrollViewer is null)
         {
@@ -535,7 +591,10 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
         }
 
         ScrollOffset = new Vector(_scrollViewer.Offset.X, _scrollViewer.Offset.Y);
-        SynchronizePinnedState(_scrollViewer);
+        if (synchronizePinnedState)
+        {
+            SynchronizePinnedState(_scrollViewer);
+        }
     }
 
     private void AttachScrollViewer()
@@ -553,6 +612,10 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
         DetachScrollViewer();
         _scrollViewer = scrollViewer;
         _scrollViewer.ScrollChanged += ScrollViewerOnScrollChanged;
+        _scrollViewerOffsetSubscription = _scrollViewer
+            .GetObservable(ScrollViewer.OffsetProperty)
+            .Subscribe(_ => ScrollViewerOffsetChanged());
+        _hasScrollMetrics = false;
     }
 
     private void DetachScrollViewer()
@@ -563,6 +626,8 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
         }
 
         _scrollViewer.ScrollChanged -= ScrollViewerOnScrollChanged;
+        _scrollViewerOffsetSubscription?.Dispose();
+        _scrollViewerOffsetSubscription = null;
         _scrollViewer = null;
     }
 
@@ -583,7 +648,13 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
             return;
         }
 
-        if (e.ExtentDelta != default || e.ViewportDelta != default)
+        if (_pendingRestoreOffset is not null)
+        {
+            return;
+        }
+
+        var metricsChanged = UpdateScrollMetrics(_scrollViewer);
+        if (metricsChanged)
         {
             ScrollOffset = new Vector(_scrollViewer.Offset.X, _scrollViewer.Offset.Y);
             if (AutoScrollToBottom && _isStuckToBottom)
@@ -595,6 +666,41 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
         }
 
         PersistScrollOffset();
+    }
+
+    private void ScrollViewerOffsetChanged()
+    {
+        if (_scrollViewer is null
+            || _isRestoringScrollOffset
+            || _suppressScrollSync
+            || !_initialLayoutComplete
+            || _pendingRestoreOffset is not null)
+        {
+            return;
+        }
+
+        if (UpdateScrollMetrics(_scrollViewer))
+        {
+            if (AutoScrollToBottom && _isStuckToBottom)
+            {
+                QueueStickToBottom();
+            }
+
+            return;
+        }
+
+        PersistScrollOffset();
+    }
+
+    private bool UpdateScrollMetrics(ScrollViewer scrollViewer)
+    {
+        var extent = scrollViewer.Extent;
+        var viewport = scrollViewer.Viewport;
+        var changed = !_hasScrollMetrics || extent != _lastExtent || viewport != _lastViewport;
+        _lastExtent = extent;
+        _lastViewport = viewport;
+        _hasScrollMetrics = true;
+        return changed;
     }
 
     private void QueueStickToBottom()

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Behaviors/PodLogsEditorBehavior.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Behaviors/PodLogsEditorBehavior.cs
@@ -247,6 +247,17 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
         {
             var metricsChanged = UpdateScrollMetrics(_scrollViewer);
 
+            if (_scrollViewer.ScrollBarMaximum.Y > 0
+                && ScrollOffset == default
+                && _scrollViewer.Offset == ScrollOffset
+                && _pendingRestoreOffset is null)
+            {
+                _isStuckToBottom = true;
+                AutoScrollToBottom = true;
+                QueueStickToBottom();
+                Dispatcher.UIThread.Post(StickToBottom, DispatcherPriority.ApplicationIdle);
+            }
+
             if (!_initialLayoutComplete && _scrollViewer.Viewport.Height > 0)
             {
                 _initialLayoutComplete = true;
@@ -654,6 +665,17 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
             return;
         }
 
+        if (ScrollOffset == default
+            && _scrollViewer.Offset == ScrollOffset
+            && _scrollViewer.ScrollBarMaximum.Y > 0)
+        {
+            _isStuckToBottom = true;
+            AutoScrollToBottom = true;
+            QueueStickToBottom();
+            Dispatcher.UIThread.Post(StickToBottom, DispatcherPriority.ApplicationIdle);
+            return;
+        }
+
         var metricsChanged = UpdateScrollMetrics(_scrollViewer);
         if (metricsChanged)
         {
@@ -677,6 +699,14 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
             || !_initialLayoutComplete
             || _pendingRestoreOffset is not null)
         {
+            return;
+        }
+
+        if (ScrollOffset == default && _scrollViewer.Offset == ScrollOffset)
+        {
+            _isStuckToBottom = true;
+            AutoScrollToBottom = true;
+            QueueStickToBottom();
             return;
         }
 

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Behaviors/PodLogsEditorBehavior.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Behaviors/PodLogsEditorBehavior.cs
@@ -55,6 +55,7 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
     private bool _isRestoringScrollOffset;
     private bool _suppressScrollSync;
     private bool _isStuckToBottom = true;
+    private bool _initialLayoutComplete;
     private bool _stickToBottomQueued;
     private bool _followLogsQueued;
     private SearchPanel? _searchPanel;
@@ -122,6 +123,7 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
 
         ApplyTheme();
         AttachScrollViewer();
+        _initialLayoutComplete = false;
         RestoreScrollOffset();
     }
 
@@ -190,6 +192,7 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
     {
         PersistScrollOffset();
         _isStuckToBottom = true;
+        _initialLayoutComplete = false;
         _stickToBottomQueued = false;
         _followLogsQueued = false;
         AttachScrollViewer();
@@ -214,6 +217,20 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
     private void AssociatedObjectOnLayoutUpdated(object? sender, EventArgs e)
     {
         AttachScrollViewer();
+
+        if (_scrollViewer is not null && !_initialLayoutComplete && _scrollViewer.Viewport.Height > 0)
+        {
+            _initialLayoutComplete = true;
+            if (AutoScrollToBottom && ScrollOffset == default)
+            {
+                _isStuckToBottom = true;
+                QueueStickToBottom();
+            }
+            else
+            {
+                SynchronizePinnedState(_scrollViewer);
+            }
+        }
 
         if (_pendingRestoreOffset is not null)
         {
@@ -561,6 +578,22 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
             return;
         }
 
+        if (!_initialLayoutComplete)
+        {
+            return;
+        }
+
+        if (e.ExtentDelta != default || e.ViewportDelta != default)
+        {
+            ScrollOffset = new Vector(_scrollViewer.Offset.X, _scrollViewer.Offset.Y);
+            if (AutoScrollToBottom && _isStuckToBottom)
+            {
+                QueueStickToBottom();
+            }
+
+            return;
+        }
+
         PersistScrollOffset();
     }
 
@@ -615,8 +648,11 @@ public sealed class PodLogsEditorBehavior : Behavior<TextEditor>, IDeclarativeVi
 
     private static bool IsAtBottom(ScrollViewer scrollViewer)
     {
-        const double threshold = 1.0;
-        return scrollViewer.ScrollBarMaximum.Y - scrollViewer.Offset.Y <= threshold;
+        const double MinimumBottomTolerance = 1.0;
+        const double HalfLineBottomTolerance = 8.0;
+        var remainingScroll = scrollViewer.ScrollBarMaximum.Y - scrollViewer.Offset.Y;
+        var tolerance = Math.Max(MinimumBottomTolerance, HalfLineBottomTolerance);
+        return remainingScroll <= tolerance;
     }
 
     private void SynchronizePinnedState(ScrollViewer scrollViewer)

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/ViewModels/PodLogsViewModel.Output.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/ViewModels/PodLogsViewModel.Output.cs
@@ -313,6 +313,22 @@ public sealed partial class PodLogsViewModel
         }
     }
 
+    private void AddOutputEntries(IReadOnlyList<PodLogOutputEntry> entries)
+    {
+        lock (_outputEntriesGate)
+        {
+            for (var i = 0; i < entries.Count; i++)
+            {
+                _outputEntries.Add(entries[i]);
+            }
+
+            if (_outputEntries.Count > MaxLogEntries)
+            {
+                _outputEntries.RemoveRange(0, _outputEntries.Count - MaxLogEntries);
+            }
+        }
+    }
+
     private static void QueueOutputEntry(List<PodLogOutputEntry> pendingOutput, PodLogReadOptions option, string message)
     {
         pendingOutput.Add(new PodLogOutputEntry(option.PodName, option.ContainerName, message));
@@ -346,10 +362,7 @@ public sealed partial class PodLogsViewModel
             return;
         }
 
-        for (var i = 0; i < entries.Count; i++)
-        {
-            AddOutputEntry(entries[i]);
-        }
+        AddOutputEntries(entries);
 
         if (_displayPaused)
         {

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/ViewModels/PodLogsViewModel.Output.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/ViewModels/PodLogsViewModel.Output.cs
@@ -9,6 +9,8 @@ namespace KubeUI.Avalonia.Resources.Workloads.v1.Pod.ViewModels;
 
 public sealed partial class PodLogsViewModel
 {
+    private const int MaxOutputBatchSize = 128;
+
     private void AppendStatusLine(string podName, string containerName, string message, CancellationTokenSource connectionCts)
     {
         if (string.IsNullOrWhiteSpace(message) || !IsCurrentConnection(connectionCts))
@@ -125,7 +127,15 @@ public sealed partial class PodLogsViewModel
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var log = await reader.ReadLineAsync(cancellationToken);
+                var read = reader.ReadLineAsync(cancellationToken);
+                // Publish quiet streams promptly, but combine already-buffered lines.
+                if (!read.IsCompletedSuccessfully || pendingOutput.Count >= MaxOutputBatchSize)
+                {
+                    await FlushOutputEntriesAsync(pendingOutput, connectionCts, outputGeneration);
+                    pendingOutput.Clear();
+                }
+
+                var log = await read;
                 if (log is null)
                 {
                     streamEnded = true;
@@ -135,8 +145,6 @@ public sealed partial class PodLogsViewModel
                 if (reconnectBuffer is null)
                 {
                     QueueOutputEntry(pendingOutput, option, log);
-                    FlushOutputEntries(pendingOutput, connectionCts, outputGeneration);
-                    pendingOutput.Clear();
                     appendedOutput = true;
                 }
                 else
@@ -148,8 +156,11 @@ public sealed partial class PodLogsViewModel
                         for (var i = 0; i < lines.Count; i++)
                         {
                             QueueOutputEntry(pendingOutput, option, lines[i]);
-                            FlushOutputEntries(pendingOutput, connectionCts, outputGeneration);
-                            pendingOutput.Clear();
+                            if (pendingOutput.Count >= MaxOutputBatchSize)
+                            {
+                                await FlushOutputEntriesAsync(pendingOutput, connectionCts, outputGeneration);
+                                pendingOutput.Clear();
+                            }
                         }
 
                         appendedOutput |= lines.Count > 0;
@@ -196,14 +207,17 @@ public sealed partial class PodLogsViewModel
                 for (var i = 0; i < lines.Count; i++)
                 {
                     QueueOutputEntry(pendingOutput, option, lines[i]);
-                    FlushOutputEntries(pendingOutput, connectionCts, outputGeneration);
-                    pendingOutput.Clear();
+                    if (pendingOutput.Count >= MaxOutputBatchSize)
+                    {
+                        await FlushOutputEntriesAsync(pendingOutput, connectionCts, outputGeneration);
+                        pendingOutput.Clear();
+                    }
                 }
 
                 appendedOutput |= lines.Count > 0;
             }
 
-            FlushOutputEntries(pendingOutput, connectionCts, outputGeneration);
+            await FlushOutputEntriesAsync(pendingOutput, connectionCts, outputGeneration);
 
             var isLastActiveReader = DecrementActiveReaders(connectionCts);
             if (((streamEnded && appendedOutput) || transientReadFailure)
@@ -293,7 +307,7 @@ public sealed partial class PodLogsViewModel
         pendingOutput.Add(new PodLogOutputEntry(option.PodName, option.ContainerName, message));
     }
 
-    private void FlushOutputEntries(
+    private async Task FlushOutputEntriesAsync(
         IReadOnlyList<PodLogOutputEntry> entries,
         CancellationTokenSource connectionCts,
         int outputGeneration)
@@ -309,7 +323,8 @@ public sealed partial class PodLogsViewModel
             AddOutputEntry(batch[i]);
         }
 
-        Dispatcher.UIThread.InvokeAsync(
+        // Backpressure bounds outstanding dispatcher work to one batch per reader.
+        await Dispatcher.UIThread.InvokeAsync(
             () => AppendOutputEntries(batch, connectionCts, outputGeneration),
             DispatcherPriority.Background);
     }
@@ -336,8 +351,11 @@ public sealed partial class PodLogsViewModel
             builder.Append(FormatOutputEntry(entries[i], ShowResourceNames, displayMode));
         }
 
-        Logs.Insert(Logs.TextLength, builder.ToString());
-        TrimLogDocument();
+        using (Logs.RunUpdate())
+        {
+            Logs.Insert(Logs.TextLength, builder.ToString());
+            TrimLogDocument();
+        }
     }
 
     private void AppendOutputEntry(PodLogOutputEntry entry, CancellationTokenSource connectionCts, int outputGeneration)
@@ -359,10 +377,10 @@ public sealed partial class PodLogsViewModel
 
     private void TrimLogDocument()
     {
-        while (Logs.LineCount > MaxLogEntries)
+        if (Logs.LineCount > MaxLogEntries)
         {
-            var firstLine = Logs.GetLineByNumber(1);
-            Logs.Remove(0, firstLine.TotalLength);
+            var firstRetainedLine = Logs.GetLineByNumber(Logs.LineCount - MaxLogEntries + 1);
+            Logs.Remove(0, firstRetainedLine.Offset);
         }
     }
 

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/ViewModels/PodLogsViewModel.Output.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/ViewModels/PodLogsViewModel.Output.cs
@@ -19,7 +19,6 @@ public sealed partial class PodLogsViewModel
         }
 
         PodLogOutputEntry entry = new(podName, containerName, message);
-        AddOutputEntry(entry);
         var outputGeneration = Volatile.Read(ref _outputGeneration);
         Dispatcher.UIThread.InvokeAsync(
             () => AppendOutputEntry(entry, connectionCts, outputGeneration),
@@ -89,7 +88,13 @@ public sealed partial class PodLogsViewModel
     {
         if (!IsMultiScope)
         {
-            return Logs.Text;
+            PodLogOutputEntry[] singleScopeEntries;
+            lock (_outputEntriesGate)
+            {
+                singleScopeEntries = _outputEntries.ToArray();
+            }
+
+            return singleScopeEntries.Length == 0 ? Logs.Text : BuildOutputText(singleScopeEntries);
         }
 
         StringBuilder builder = new();
@@ -106,7 +111,13 @@ public sealed partial class PodLogsViewModel
         }
 
         builder.AppendLine();
-        builder.Append(Logs.Text);
+        PodLogOutputEntry[] exportEntries;
+        lock (_outputEntriesGate)
+        {
+            exportEntries = _outputEntries.ToArray();
+        }
+
+        builder.Append(exportEntries.Length == 0 ? Logs.Text : BuildOutputText(exportEntries));
         return builder.ToString();
     }
 
@@ -318,10 +329,6 @@ public sealed partial class PodLogsViewModel
         }
 
         PodLogOutputEntry[] batch = entries.ToArray();
-        for (var i = 0; i < batch.Length; i++)
-        {
-            AddOutputEntry(batch[i]);
-        }
 
         // Backpressure bounds outstanding dispatcher work to one batch per reader.
         await Dispatcher.UIThread.InvokeAsync(
@@ -336,6 +343,17 @@ public sealed partial class PodLogsViewModel
     {
         if (!IsCurrentConnection(connectionCts) || outputGeneration != Volatile.Read(ref _outputGeneration))
         {
+            return;
+        }
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            AddOutputEntry(entries[i]);
+        }
+
+        if (_displayPaused)
+        {
+            PendingLogCount += entries.Count;
             return;
         }
 
@@ -362,6 +380,14 @@ public sealed partial class PodLogsViewModel
     {
         if (!IsCurrentConnection(connectionCts) || outputGeneration != Volatile.Read(ref _outputGeneration))
         {
+            return;
+        }
+
+        AddOutputEntry(entry);
+
+        if (_displayPaused)
+        {
+            PendingLogCount++;
             return;
         }
 
@@ -393,21 +419,30 @@ public sealed partial class PodLogsViewModel
 
     private void RenderOutputEntries()
     {
+        if (_displayPaused)
+        {
+            return;
+        }
+
         PodLogOutputEntry[] entries;
         lock (_outputEntriesGate)
         {
             if (_outputEntries.Count == 0)
             {
-                Logs.Text = string.Empty;
                 return;
             }
 
             entries = _outputEntries.ToArray();
         }
 
+        Logs.Text = BuildOutputText(entries);
+    }
+
+    private string BuildOutputText(IReadOnlyList<PodLogOutputEntry> entries)
+    {
         StringBuilder builder = new();
         var displayMode = GetCurrentDisplayMode();
-        for (var i = 0; i < entries.Length; i++)
+        for (var i = 0; i < entries.Count; i++)
         {
             if (i > 0)
             {
@@ -417,7 +452,7 @@ public sealed partial class PodLogsViewModel
             builder.Append(FormatOutputEntry(entries[i], ShowResourceNames, displayMode));
         }
 
-        Logs.Text = builder.ToString();
+        return builder.ToString();
     }
 
     private static string FormatOutputEntry(PodLogOutputEntry entry, bool showResourceNames, PodLogDisplayMode displayMode)

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/ViewModels/PodLogsViewModel.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/ViewModels/PodLogsViewModel.cs
@@ -52,6 +52,7 @@ public sealed partial class PodLogsViewModel : ViewModelBase, IDisposable
     private int _streamEndedReconnectPending;
     private int _activeReaderCount;
     private int _outputGeneration;
+    private bool _displayPaused;
     private PodLogDisplayMode _resourceNameDisplayMode;
     private bool _awaitingReadableTargets;
     private IDisposable? _resourceChangesSubscription;
@@ -272,6 +273,23 @@ public sealed partial class PodLogsViewModel : ViewModelBase, IDisposable
     [ObservableProperty]
     /// <summary>Gets or sets the request to resume following the newest logs.</summary>
     public partial bool FollowLogsRequested { get; set; }
+
+    [ObservableProperty]
+    /// <summary>Gets the number of log entries received while the display was paused.</summary>
+    public partial int PendingLogCount { get; private set; }
+
+    /// <summary>Gets whether log entries are waiting to be displayed.</summary>
+    public bool HasPendingLogUpdates => PendingLogCount > 0;
+
+    /// <summary>Gets whether the displayed log document is paused while the stream continues.</summary>
+    public bool IsDisplayPaused => _displayPaused;
+
+    /// <summary>Gets the status shown while the display is paused and new entries arrive.</summary>
+    public string LogUpdateStatus => !IsDisplayPaused
+        ? string.Empty
+        : HasPendingLogUpdates
+            ? string.Format(CultureInfo.CurrentCulture, Assets.Resources.PodLogsView_LogUpdatesPaused, PendingLogCount)
+            : Assets.Resources.PodLogsView_UpdatesPaused;
 
     [ObservableProperty]
     /// <summary>Gets or sets the persisted editor scroll offset.</summary>
@@ -781,8 +799,33 @@ public sealed partial class PodLogsViewModel : ViewModelBase, IDisposable
     {
         if (value)
         {
+            SetDisplayPaused(false);
+            PendingLogCount = 0;
+            RenderOutputEntries();
             FollowLogsRequested = true;
         }
+        else
+        {
+            SetDisplayPaused(true);
+        }
+    }
+
+    partial void OnPendingLogCountChanged(int value)
+    {
+        OnPropertyChanged(nameof(HasPendingLogUpdates));
+        OnPropertyChanged(nameof(LogUpdateStatus));
+    }
+
+    private void SetDisplayPaused(bool value)
+    {
+        if (_displayPaused == value)
+        {
+            return;
+        }
+
+        _displayPaused = value;
+        OnPropertyChanged(nameof(IsDisplayPaused));
+        OnPropertyChanged(nameof(LogUpdateStatus));
     }
 
     partial void OnObjectChanged(IKubernetesObject<V1ObjectMeta>? value)
@@ -1358,6 +1401,8 @@ public sealed partial class PodLogsViewModel : ViewModelBase, IDisposable
     {
         Interlocked.Increment(ref _outputGeneration);
         Logs.Text = string.Empty;
+        SetDisplayPaused(!AutoScrollToBottom);
+        PendingLogCount = 0;
         lock (_outputEntriesGate)
         {
             _outputEntries.Clear();

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Views/PodLogsView.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/Views/PodLogsView.cs
@@ -84,7 +84,23 @@ public sealed partial class PodLogsView : ViewBase<PodLogsViewModel>
                         new TextBlock()
                             .MaxWidth(320)
                             .Text(vm, x => x.StreamLimitWarning)
-                            .TextTrimming(TextTrimming.CharacterEllipsis)));
+                            .TextTrimming(TextTrimming.CharacterEllipsis)),
+                new StackPanel()
+                    .Orientation(Orientation.Horizontal)
+                    .Spacing(4)
+                    .VerticalAlignment(VerticalAlignment.Center)
+                    .IsVisible(vm, x => x.IsDisplayPaused)
+                    .Children(
+                        new FluentIcon().Icon(Icon.Warning),
+                        new TextBlock()
+                            .MaxWidth(320)
+                            .VerticalAlignment(VerticalAlignment.Center)
+                            .Text(vm, x => x.LogUpdateStatus)
+                            .TextTrimming(TextTrimming.CharacterEllipsis),
+                        new Button()
+                            .VerticalAlignment(VerticalAlignment.Center)
+                            .Command(vm, x => x.FollowLogsCommand)
+                            .Content(Assets.Resources.PodLogsView_ResumeFollowing)));
     }
 
     private static TreeComboBox CreateSourcesSelector(PodLogsViewModel vm)

--- a/tests/KubeUI.Avalonia.Tests/Resources/Workloads/v1/Pod/PodLogsViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Resources/Workloads/v1/Pod/PodLogsViewModelTests.cs
@@ -2321,6 +2321,25 @@ public sealed class PodLogsViewModelTests
         viewModel.FollowLogsRequested.ShouldBeTrue();
     }
 
+    [AvaloniaFact]
+    public async Task Disabling_follow_logs_should_pause_the_display_until_resumed()
+    {
+        using var workspace = await Application.Current.CreateClusterAsync();
+        using PodLogsViewModel viewModel = CreateViewModel(workspace.Runtime, new RecordingPodLogStreamClient());
+
+        viewModel.Logs.Text = "existing line";
+        viewModel.AutoScrollToBottom = false;
+
+        viewModel.IsDisplayPaused.ShouldBeTrue();
+        viewModel.LogUpdateStatus.ShouldBe(KubeUI.Avalonia.Assets.Resources.PodLogsView_UpdatesPaused);
+
+        viewModel.FollowLogs();
+
+        viewModel.IsDisplayPaused.ShouldBeFalse();
+        viewModel.HasPendingLogUpdates.ShouldBeFalse();
+        viewModel.LogUpdateStatus.ShouldBe(string.Empty);
+    }
+
     [AvaloniaTheory, KubernetesBackendData]
     [Trait("Category", "Kind")]
     public async Task Connect_should_disable_resource_names_in_single_pod_single_container_mode(KubernetesBackend backend)

--- a/tests/KubeUI.Avalonia.Tests/Resources/Workloads/v1/Pod/PodLogsViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Resources/Workloads/v1/Pod/PodLogsViewModelTests.cs
@@ -2340,6 +2340,40 @@ public sealed class PodLogsViewModelTests
         viewModel.LogUpdateStatus.ShouldBe(string.Empty);
     }
 
+    [AvaloniaFact]
+    public async Task Paused_display_should_buffer_streamed_output_until_following_resumes()
+    {
+        using var workspace = await Application.Current.CreateClusterAsync();
+        V1Pod pod = CreatePod(
+            name: "app",
+            namespaceName: "default",
+            uid: "app-uid",
+            containers: ["app"]);
+        await workspace.Runtime.AddOrUpdateResource(pod);
+        await workspace.Runtime.SeedResource<V1Pod>(true);
+
+        BlockingPodLogStreamClient streamClient = new("new line 1\nnew line 2\n");
+        using PodLogsViewModel viewModel = CreateViewModel(workspace.Runtime, streamClient);
+        viewModel.Object = pod;
+        viewModel.ContainerName = "app";
+
+        Task connectTask = viewModel.Connect();
+        await streamClient.WaitForFirstRequestAsync();
+
+        viewModel.Logs.Text = "existing line";
+        viewModel.AutoScrollToBottom = false;
+        streamClient.ReleaseFirstRequest();
+
+        await WaitForAsync(() => viewModel.PendingLogCount == 2);
+        viewModel.Logs.Text.ShouldBe("existing line");
+
+        viewModel.FollowLogs();
+
+        await WaitForAsync(() => viewModel.Logs.Text.Contains("new line 2", StringComparison.Ordinal));
+        viewModel.PendingLogCount.ShouldBe(0);
+        await connectTask;
+    }
+
     [AvaloniaTheory, KubernetesBackendData]
     [Trait("Category", "Kind")]
     public async Task Connect_should_disable_resource_names_in_single_pod_single_container_mode(KubernetesBackend backend)

--- a/tests/KubeUI.Avalonia.Tests/Resources/Workloads/v1/Pod/PodLogsViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Resources/Workloads/v1/Pod/PodLogsViewModelTests.cs
@@ -22,6 +22,34 @@ namespace KubeUI.Avalonia.Tests.Resources.Workloads.v1.Pod;
 
 public sealed class PodLogsViewModelTests
 {
+    [AvaloniaFact]
+    public async Task Connect_should_batch_buffered_logs_to_keep_ui_updates_bounded()
+    {
+        using var workspace = await Application.Current.CreateClusterAsync();
+        V1Pod pod = CreatePod("app", "default", "pod-uid", containers: ["app"]);
+        await workspace.Runtime.AddOrUpdateResource(pod);
+        await workspace.Runtime.SeedResource<V1Pod>(true);
+        var payload = string.Join('\n', Enumerable.Range(1, 500).Select(index => $"line-{index}"));
+        RecordingPodLogStreamClient streamClient = new([payload]);
+        using PodLogsViewModel viewModel = CreateViewModel(workspace.Runtime, streamClient);
+        viewModel.Object = pod;
+        viewModel.ContainerName = "app";
+        var updates = 0;
+        EventHandler onChanged = (_, _) => updates++;
+        viewModel.Logs.TextChanged += onChanged;
+        try
+        {
+            await viewModel.Connect();
+            await WaitForAsync(() => viewModel.Logs.Text.EndsWith("line-500", StringComparison.Ordinal));
+            viewModel.Logs.Text.ShouldBe(payload.Replace("\n", Environment.NewLine));
+            updates.ShouldBeLessThan(20);
+        }
+        finally
+        {
+            viewModel.Logs.TextChanged -= onChanged;
+        }
+    }
+
     [AvaloniaTheory, KubernetesBackendData]
     [Trait("Category", "Kind")]
     public async Task Deployment_rollout_should_switch_logs_to_the_new_pod_without_refresh(KubernetesBackend backend)

--- a/tests/KubeUI.Avalonia.Tests/Resources/Workloads/v1/Pod/PodLogsViewTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Resources/Workloads/v1/Pod/PodLogsViewTests.cs
@@ -527,12 +527,16 @@ public sealed class PodLogsViewTests
             window.Height = 180;
 
             await WaitForAsync(() => scrollViewer.ScrollBarMaximum.Y > 0);
-            await WaitForAsync(() => !viewModel.AutoScrollToBottom && followLogsButton.IsEnabled);
+            await WaitForAsync(() => viewModel.AutoScrollToBottom
+                && scrollViewer.Offset.Y >= scrollViewer.ScrollBarMaximum.Y - 1.0
+                && followLogsButton.IsEnabled);
+            followLogsButton.IsEnabled.ShouldBeTrue();
+            followLogsButton.IsChecked.ShouldBe(true);
 
             await Dispatcher.UIThread.InvokeAsync(() =>
-                scrollViewer.Offset = new Vector(scrollViewer.Offset.X, scrollViewer.ScrollBarMaximum.Y));
+                scrollViewer.Offset = new Vector(scrollViewer.Offset.X, scrollViewer.ScrollBarMaximum.Y - 4));
             await WaitForAsync(() => viewModel.AutoScrollToBottom);
-            followLogsButton.IsEnabled.ShouldBeTrue();
+            followLogsButton.IsChecked.ShouldBe(true);
         }
         finally
         {
@@ -956,6 +960,42 @@ public sealed class PodLogsViewTests
 
             topBar.Bounds.Height.ShouldBeLessThanOrEqualTo(32);
             sourcesSelector.Bounds.Height.ShouldBeLessThanOrEqualTo(32);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task view_follows_initial_logs_after_the_editor_is_measured()
+    {
+        using var workspace = await Application.Current.CreateClusterAsync();
+        IServiceProvider services = Application.Current.GetTestServices();
+        using PodLogsViewModel viewModel = new(
+            services.GetRequiredService<ILogger<PodLogsViewModel>>(),
+            services.GetRequiredService<ISettingsService>(),
+            new NoOpPodLogExportService(),
+            new PodLogSessionResolver(),
+            new NoOpPodLogStreamClient())
+        {
+            Cluster = workspace.Runtime,
+            Object = CreatePod(),
+            ContainerName = "app",
+            Logs = new AvaloniaEdit.Document.TextDocument(CreateManyLines(300)),
+        };
+
+        PodLogsView view = new() { DataContext = viewModel };
+        Window window = new() { Content = view, Width = 800, Height = 300 };
+        window.Show();
+        try
+        {
+            TextEditor editor = view.GetVisualDescendants().OfType<TextEditor>().Single();
+            ScrollViewer scrollViewer = await WaitForScrollViewerAsync(editor);
+            await WaitForAsync(() => scrollViewer.ScrollBarMaximum.Y > 0);
+            await WaitForAsync(() => scrollViewer.Offset.Y >= scrollViewer.ScrollBarMaximum.Y - 1.0);
+
+            viewModel.AutoScrollToBottom.ShouldBeTrue();
         }
         finally
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pod logs now pause visibly when Follow Logs is disabled or the view is scrolled away from the bottom.
  * Displays pending line counts and provides a Resume Following action.
  * Keeps the view pinned to the bottom during log updates and resizing.

* **Bug Fixes**
  * Improved log streaming performance while preserving complete buffered output.
  * Improved retained-log trimming and initial scroll positioning.

* **Tests**
  * Added coverage for paused logs, resuming, buffered output, and follow-mode scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->