### PR TITLE
fix: update resource informer handling to run on background tasks and add tests for typed resource informers

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,14 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+            path: ~/.nuget/packages
+            key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', 'global.json') }}
+            restore-keys: |
+              ${{ runner.os }}-nuget-
+
       - name: Build
         run: dotnet build --configuration Release --tl:off -clp:ErrorsOnly
 

--- a/.github/workflows/publish-installer.yml
+++ b/.github/workflows/publish-installer.yml
@@ -69,6 +69,14 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+            path: ~/.nuget/packages
+            key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', 'global.json') }}
+            restore-keys: |
+              ${{ runner.os }}-nuget-
+
       - name: Install Velopack
         shell: pwsh
         run: |

--- a/src/KubeUI.Kubernetes/Client/Cluster.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.cs
@@ -355,8 +355,9 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
 
             informer.StartWatching();
 
-            _resourceInformerTasks.Add(informer.RunInfinite(GetResourceInformerCancellationToken()));
-            await informer.ReadyAsync(GetResourceInformerCancellationToken()).ConfigureAwait(false);
+            var informerCancellationToken = GetResourceInformerCancellationToken();
+            _resourceInformerTasks.Add(Task.Run(() => informer.RunInfinite(informerCancellationToken)));
+            await informer.ReadyAsync(informerCancellationToken).ConfigureAwait(false);
 
             if (container.IsSeeded)
             {

--- a/src/KubeUI.Kubernetes/Client/Cluster.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.cs
@@ -295,8 +295,9 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
             typeof(T),
             waitForReady => SeedResource<T>(waitForReady));
         var container = (ContainerClass<T>)Objects.GetOrAdd(kind, _ => new ContainerClass<T>());
+        var informerCancellationToken = GetResourceInformerCancellationToken();
         var seedTask = container.GetOrCreateSeedTask(() =>
-            Task.Run(() => SeedResourceCoreAsync<T>()));
+            Task.Run(() => SeedResourceCoreAsync<T>(informerCancellationToken)));
 
         _logger.LogDebug("Seed requested for {kind}.", kind);
 
@@ -314,7 +315,7 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
         if (waitForReady)
         {
             _logger.LogDebug("Waiting for resource readiness for {type}.", typeof(T));
-            await IsResourceReady<T>().ConfigureAwait(false);
+            await IsResourceReady<T>(informerCancellationToken).ConfigureAwait(false);
             _logger.LogDebug("Resource readiness reached for {type}.", typeof(T));
         }
 
@@ -419,7 +420,7 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
         });
     }
 
-    private async Task SeedResourceCoreAsync<T>() where T : class, IKubernetesObject<V1ObjectMeta>, new()
+    private async Task SeedResourceCoreAsync<T>(CancellationToken informerCancellationToken) where T : class, IKubernetesObject<V1ObjectMeta>, new()
     {
         _logger.LogDebug("Starting seed initialization for {type}.", typeof(T));
 
@@ -434,7 +435,6 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
             container.InformerRegistrations.Add(informer.Register(GetResourceInformerCallback<T>()));
             informer.StartWatching();
 
-            var informerCancellationToken = GetResourceInformerCancellationToken();
             _resourceInformerTasks.Add(Task.Run(() => informer.RunInfinite(informerCancellationToken)));
         }
         else
@@ -455,7 +455,6 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
                     container.InformerRegistrations.Add(informer.Register(GetResourceInformerCallback<T>()));
                     informer.StartWatching();
 
-                    var informerCancellationToken = GetResourceInformerCancellationToken();
                     _resourceInformerTasks.Add(Task.Run(() => informer.RunInfinite(informerCancellationToken)));
                 }
             }

--- a/src/KubeUI.Kubernetes/Client/Cluster.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.cs
@@ -433,7 +433,9 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
             container.Informers.Add(informer);
             container.InformerRegistrations.Add(informer.Register(GetResourceInformerCallback<T>()));
             informer.StartWatching();
-            _ = informer.RunInfinite(GetResourceInformerCancellationToken());
+
+            var informerCancellationToken = GetResourceInformerCancellationToken();
+            _resourceInformerTasks.Add(Task.Run(() => informer.RunInfinite(informerCancellationToken)));
         }
         else
         {
@@ -452,7 +454,9 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
                     container.Informers.Add(informer);
                     container.InformerRegistrations.Add(informer.Register(GetResourceInformerCallback<T>()));
                     informer.StartWatching();
-                    _resourceInformerTasks.Add(informer.RunInfinite(GetResourceInformerCancellationToken()));
+
+                    var informerCancellationToken = GetResourceInformerCancellationToken();
+                    _resourceInformerTasks.Add(Task.Run(() => informer.RunInfinite(informerCancellationToken)));
                 }
             }
         }

--- a/tests/KubeUI.Avalonia.Tests/Shell/Navigation/NavigationViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Shell/Navigation/NavigationViewModelTests.cs
@@ -303,6 +303,25 @@ public class NavigationViewModelTests
         return new GroupApiVersionKind(crd.Spec.Group, version, crd.Spec.Names.Kind, crd.Spec.Names.Plural);
     }
 
+    private static V1CustomResourceDefinition CreateComplexManagedResourceDefinition()
+    {
+        var crd = NavigationTestCustomResourceDefinitionFactory.Create(
+            "managedresourcedefinitions.crossplane.io",
+            "managedresourcedefinitions",
+            "providerConfigRef",
+            "crossplane.io");
+        crd.Spec.Names.Kind = "ManagedResourceDefinition";
+        crd.Spec.Names.Singular = "managedresourcedefinition";
+        crd.Spec.Versions[0].AdditionalPrinterColumns =
+        [
+            new() { Name = "Provider", JsonPath = ".spec.providerConfigRef.name", Type = "string" },
+            new() { Name = "Ready", JsonPath = ".status.conditions[?(@.type==\"Ready\")].status", Type = "string" },
+            new() { Name = "Synced", JsonPath = ".status.conditions[?(@.type==\"Synced\")].status", Type = "string" },
+            new() { Name = "External Name", JsonPath = ".metadata.annotations['crossplane.io/external-name']", Type = "string" },
+        ];
+        return crd;
+    }
+
     [AvaloniaFact]
     public async Task resource_navigation_items_populate_only_after_connect_completes()
     {
@@ -357,6 +376,84 @@ public class NavigationViewModelTests
         (await WaitForValueAsync(
             () => FindResourceLink(crdRoot.NavigationItems, GetCustomResourceKind(secondCrd)),
             timeoutMs: 10000)).ShouldNotBeNull();
+    }
+
+    [AvaloniaFact]
+    public async Task opening_custom_resource_list_does_not_run_custom_resource_informer_on_ui_thread()
+    {
+        var crd = CreateComplexManagedResourceDefinition();
+        var resources = Enumerable.Range(0, 128)
+            .Select(index => new TestCrossplaneManagedResourceDefinition
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Name = $"managed-resource-{index}",
+                    NamespaceProperty = "default",
+                },
+            })
+            .Cast<IKubernetesObject<V1ObjectMeta>>()
+            .ToArray();
+        var workspace = await Application.Current.CreateClusterAsync(
+            config => config.InitialResources = [crd, .. resources],
+            connect: false);
+        using var vm = CreateViewModel();
+        vm.ClusterCatalog.Clusters.Add(workspace);
+
+        await workspace.Connect();
+        await workspace.Runtime.SeedResource<V1CustomResourceDefinition>(true);
+
+        var resourceKind = GetCustomResourceKind(crd);
+        await WaitForAsync(() => workspace.Runtime.ModelCatalog.IsCustomResource(resourceKind), timeoutMs: 10000);
+        var resourceLink = await WaitForValueAsync(
+            () => FindResourceLink(vm.Clusters.Single(x => x.Cluster == workspace), resourceKind),
+            timeoutMs: 10000);
+        resourceLink.ShouldNotBeNull();
+
+        var resourceSeededOnUiThread = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnResourceSeeded(IClusterRuntime _, GroupApiVersionKind kind)
+        {
+            if (kind == resourceKind)
+            {
+                resourceSeededOnUiThread.TrySetResult(Dispatcher.UIThread.CheckAccess());
+            }
+        }
+
+        workspace.Runtime.ResourceSeeded += OnResourceSeeded;
+        try
+        {
+            var openCompletion = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Dispatcher.UIThread.Post(async () =>
+            {
+                try
+                {
+                    await vm.TreeViewSelectionChangedAsync(resourceLink);
+                    openCompletion.TrySetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    openCompletion.TrySetResult(ex);
+                }
+            });
+
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var timeout = TestWait.NextPollAsync(TimeSpan.FromSeconds(5), cancellationToken);
+            if (await Task.WhenAny(openCompletion.Task, timeout).ConfigureAwait(false) != openCompletion.Task)
+            {
+                await workspace.Disconnect().ConfigureAwait(false);
+            }
+
+            var openError = await openCompletion.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken).ConfigureAwait(false);
+            openError.ShouldBeNull();
+
+            var resourceSeededWasOnUiThread = await resourceSeededOnUiThread.Task
+                .WaitAsync(TimeSpan.FromSeconds(10), cancellationToken)
+                .ConfigureAwait(false);
+            resourceSeededWasOnUiThread.ShouldBeFalse();
+        }
+        finally
+        {
+            workspace.Runtime.ResourceSeeded -= OnResourceSeeded;
+        }
     }
 
     [AvaloniaFact]
@@ -2393,6 +2490,14 @@ internal class TestCustomResourceNested : IKubernetesObject<V1ObjectMeta>
 {
     public string ApiVersion { get; set; } = "mygroup.test.kubeui.com/v1";
     public string Kind { get; set; } = "TestCustomResourceNested";
+    public V1ObjectMeta Metadata { get; set; } = new();
+}
+
+[KubernetesEntity(Group = "crossplane.io", ApiVersion = "v1beta1", Kind = "ManagedResourceDefinition")]
+internal sealed class TestCrossplaneManagedResourceDefinition : IKubernetesObject<V1ObjectMeta>
+{
+    public string ApiVersion { get; set; } = "crossplane.io/v1beta1";
+    public string Kind { get; set; } = "ManagedResourceDefinition";
     public V1ObjectMeta Metadata { get; set; } = new();
 }
 

--- a/tests/KubeUI.Avalonia.Tests/Shell/Navigation/NavigationViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Shell/Navigation/NavigationViewModelTests.cs
@@ -457,6 +457,85 @@ public class NavigationViewModelTests
     }
 
     [AvaloniaFact]
+    public async Task opening_typed_resource_list_does_not_run_typed_resource_informer_on_ui_thread()
+    {
+        var resources = Enumerable.Range(0, 128)
+            .Select(index => new V1Pod
+            {
+                Metadata = new V1ObjectMeta
+                {
+                    Name = $"managed-pod-{index}",
+                    NamespaceProperty = "default",
+                },
+                Spec = new V1PodSpec
+                {
+                    Containers =
+                    [
+                        new V1Container
+                        {
+                            Name = "provider",
+                            Image = "crossplane/provider-aws:v1.0.0",
+                        },
+                    ],
+                },
+            })
+            .Cast<IKubernetesObject<V1ObjectMeta>>()
+            .ToArray();
+        using var workspace = await Application.Current.CreateClusterAsync(
+            config => config.InitialResources = resources,
+            connect: false);
+        using var vm = CreateViewModel();
+        vm.ClusterCatalog.Clusters.Add(workspace);
+
+        await workspace.Connect();
+        var clusterNode = vm.Clusters.Single(x => x.Cluster == workspace);
+        var resourceLink = await WaitForValueAsync(
+            () => FindResourceLink(clusterNode, GroupApiVersionKind.From<V1Pod>()),
+            timeoutMs: 10000);
+        resourceLink.ShouldNotBeNull();
+
+        var resourceSeededOnUiThread = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnResourceSeeded(IClusterRuntime _, GroupApiVersionKind kind)
+        {
+            if (kind == GroupApiVersionKind.From<V1Pod>())
+            {
+                resourceSeededOnUiThread.TrySetResult(Dispatcher.UIThread.CheckAccess());
+            }
+        }
+
+        workspace.Runtime.ResourceSeeded += OnResourceSeeded;
+        try
+        {
+            var openCompletion = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Dispatcher.UIThread.Post(async () =>
+            {
+                try
+                {
+                    await vm.TreeViewSelectionChangedAsync(resourceLink);
+                    openCompletion.TrySetResult(null);
+                }
+                catch (Exception ex)
+                {
+                    openCompletion.TrySetResult(ex);
+                }
+            });
+
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var openError = await openCompletion.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken).ConfigureAwait(false);
+            openError.ShouldBeNull();
+
+            var resourceSeededWasOnUiThread = await resourceSeededOnUiThread.Task
+                .WaitAsync(TimeSpan.FromSeconds(10), cancellationToken)
+                .ConfigureAwait(false);
+            resourceSeededWasOnUiThread.ShouldBeFalse();
+        }
+        finally
+        {
+            workspace.Runtime.ResourceSeeded -= OnResourceSeeded;
+        }
+    }
+
+    [AvaloniaFact]
     public async Task selecting_cluster_node_does_not_crash_when_connect_fails()
     {
         var services = Application.Current.GetTestServices();

--- a/tests/KubeUI.Kubernetes.Tests/Clusters/Runtime/ClusterRuntimeTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/Clusters/Runtime/ClusterRuntimeTests.cs
@@ -26,6 +26,18 @@ public sealed class ClusterRuntimeTests : ClusterRuntimeAssertions
     }
 
     [Fact]
+    public async Task TypedResourceInformerIsTrackedForShutdown()
+    {
+        await using var clusterScope = await new TestClusterGenerator().CreateAsync(new TestClusterConfig(), TestContext.Current.CancellationToken);
+        var cluster = clusterScope.Cluster;
+        await cluster.Connect();
+
+        await cluster.SeedResource<V1Pod>(waitForReady: true);
+
+        cluster.ActiveResourceInformerTaskCount.ShouldBeGreaterThan(0);
+    }
+
+    [Fact]
     public async Task ScenarioSeedsTypedInitialResources()
     {
         await using var clusterScope = await new TestClusterGenerator().CreateAsync(

--- a/tests/KubeUI.Kubernetes.Tests/Clusters/Runtime/ClusterRuntimeTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/Clusters/Runtime/ClusterRuntimeTests.cs
@@ -30,9 +30,9 @@ public sealed class ClusterRuntimeTests : ClusterRuntimeAssertions
     {
         await using var clusterScope = await new TestClusterGenerator().CreateAsync(new TestClusterConfig(), TestContext.Current.CancellationToken);
         var cluster = clusterScope.Cluster;
-        await cluster.Connect();
-
         var activeInformerTaskCountBeforeSeeding = cluster.ActiveResourceInformerTaskCount;
+
+        await cluster.Connect();
         await cluster.SeedResource<V1Pod>(waitForReady: true);
 
         cluster.ActiveResourceInformerTaskCount.ShouldBeGreaterThan(activeInformerTaskCountBeforeSeeding);

--- a/tests/KubeUI.Kubernetes.Tests/Clusters/Runtime/ClusterRuntimeTests.cs
+++ b/tests/KubeUI.Kubernetes.Tests/Clusters/Runtime/ClusterRuntimeTests.cs
@@ -32,9 +32,10 @@ public sealed class ClusterRuntimeTests : ClusterRuntimeAssertions
         var cluster = clusterScope.Cluster;
         await cluster.Connect();
 
+        var activeInformerTaskCountBeforeSeeding = cluster.ActiveResourceInformerTaskCount;
         await cluster.SeedResource<V1Pod>(waitForReady: true);
 
-        cluster.ActiveResourceInformerTaskCount.ShouldBeGreaterThan(0);
+        cluster.ActiveResourceInformerTaskCount.ShouldBeGreaterThan(activeInformerTaskCountBeforeSeeding);
     }
 
     [Fact]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resource informers now run asynchronously without blocking the UI thread when opening custom or typed resource lists.
  - Informer operations are tracked to support more reliable shutdown and cancellation.

- **Tests**
  - Added coverage for UI responsiveness during resource loading.
  - Added verification that active informer tasks are tracked correctly.

- **Chores**
  - Added caching for NuGet packages in the build and test workflow to improve execution efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->