### PR TITLE
fix: implement refresh timer handling and subscription management in …

### DIFF
--- a/src/KubeUI.Avalonia/Features/Clusters/Overview/ClusterView.cs
+++ b/src/KubeUI.Avalonia/Features/Clusters/Overview/ClusterView.cs
@@ -167,6 +167,11 @@ public sealed partial class ClusterView : ViewBase<ClusterViewModel>
 
     private void StartRefreshTimer()
     {
+        if (VisualRoot == null)
+        {
+            return;
+        }
+
         if (!_timer.IsEnabled)
         {
             _timer.Interval = TimeSpan.FromSeconds(1);

--- a/src/KubeUI.Avalonia/Features/Clusters/Overview/ClusterView.cs
+++ b/src/KubeUI.Avalonia/Features/Clusters/Overview/ClusterView.cs
@@ -156,7 +156,17 @@ public sealed partial class ClusterView : ViewBase<ClusterViewModel>
     protected override void OnDataContextChanged(EventArgs e)
     {
         base.OnDataContextChanged(e);
+        StartRefreshTimer();
+    }
 
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        StartRefreshTimer();
+    }
+
+    private void StartRefreshTimer()
+    {
         if (!_timer.IsEnabled)
         {
             _timer.Interval = TimeSpan.FromSeconds(1);

--- a/src/KubeUI.Avalonia/Infrastructure/Mcp/McpClusterSession.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/Mcp/McpClusterSession.cs
@@ -79,7 +79,7 @@ internal sealed class McpClusterSession(
         var workspace = workspaceCatalog.GetCluster(cluster.Name)
             ?? throw new InvalidOperationException($"Cluster {cluster.Name} is not backed by a KubeUI workspace.");
 
-        await workspace.GetResourceConfig(resourceKind).SeedResource().ConfigureAwait(false);
+        await workspace.GetResourceConfig(resourceKind).SeedResource(waitForReady: true).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<IKubernetesObject<V1ObjectMeta>>> ListResourcesAsync(
@@ -94,7 +94,7 @@ internal sealed class McpClusterSession(
         var resourceKind = ResolveResourceKind(cluster, workspace, apiVersion, kind);
         if (!cluster.ModelCatalog.Contains(resourceKind))
             throw new InvalidOperationException($"Unable to resolve Kubernetes resource for {apiVersion}/{kind}.");
-        await workspace.GetResourceConfig(resourceKind).SeedResource().ConfigureAwait(false);
+        await workspace.GetResourceConfig(resourceKind).SeedResource(waitForReady: true).ConfigureAwait(false);
         if (!cluster.Objects.TryGetValue(resourceKind, out var value)
             || value is not IResourceContainer container)
             return [];
@@ -131,7 +131,7 @@ internal sealed class McpClusterSession(
         var resourceKind = ResolveResourceKind(cluster, workspace, apiVersion, kind);
         if (!cluster.ModelCatalog.Contains(resourceKind))
             throw new InvalidOperationException($"Unable to resolve Kubernetes resource for {apiVersion}/{kind}.");
-        await workspace.GetResourceConfig(resourceKind).SeedResource().ConfigureAwait(false);
+        await workspace.GetResourceConfig(resourceKind).SeedResource(waitForReady: true).ConfigureAwait(false);
 
         var resources = cluster.Objects.Values
             .OfType<IResourceContainer>()

--- a/src/KubeUI.Avalonia/Infrastructure/Mcp/McpClusterSession.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/Mcp/McpClusterSession.cs
@@ -25,14 +25,14 @@ public sealed record McpResourceGraphInfo(
 public interface IMcpClusterSession
 {
     Task<IClusterRuntime> GetConnectedClusterAsync(string? clusterName);
-    Task SeedResourceAsync(string? clusterName, GroupApiVersionKind resourceKind);
+    Task SeedResourceAsync(string? clusterName, GroupApiVersionKind resourceKind, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<McpSupportedResourceInfo>> ListSupportedResourcesAsync(string? clusterName);
     Task<IReadOnlyList<IKubernetesObject<V1ObjectMeta>>> ListResourcesAsync(
-        string? clusterName, string apiVersion, string kind, string? @namespace, int limit);
+        string? clusterName, string apiVersion, string kind, string? @namespace, int limit, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<McpRelatedResourceInfo>> ListRelatedResourcesAsync(
-        string? clusterName, string apiVersion, string kind, string name, string? @namespace, int limit);
+        string? clusterName, string apiVersion, string kind, string name, string? @namespace, int limit, CancellationToken cancellationToken = default);
     Task<McpResourceGraphInfo> GetResourceGraphAsync(
-        string? clusterName, string apiVersion, string kind, string name, string? @namespace, int limit);
+        string? clusterName, string apiVersion, string kind, string name, string? @namespace, int limit, CancellationToken cancellationToken = default);
 }
 
 internal sealed class McpClusterSession(
@@ -73,17 +73,17 @@ internal sealed class McpClusterSession(
                 config.IsCustomResource, config.CanListAndWatch, config.PermissionsLoaded))];
     }
 
-    public async Task SeedResourceAsync(string? clusterName, GroupApiVersionKind resourceKind)
+    public async Task SeedResourceAsync(string? clusterName, GroupApiVersionKind resourceKind, CancellationToken cancellationToken = default)
     {
         var cluster = await GetConnectedClusterAsync(clusterName).ConfigureAwait(false);
         var workspace = workspaceCatalog.GetCluster(cluster.Name)
             ?? throw new InvalidOperationException($"Cluster {cluster.Name} is not backed by a KubeUI workspace.");
 
-        await workspace.GetResourceConfig(resourceKind).SeedResource(waitForReady: true).ConfigureAwait(false);
+        await workspace.GetResourceConfig(resourceKind).SeedResource(waitForReady: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<IKubernetesObject<V1ObjectMeta>>> ListResourcesAsync(
-        string? clusterName, string apiVersion, string kind, string? @namespace, int limit)
+        string? clusterName, string apiVersion, string kind, string? @namespace, int limit, CancellationToken cancellationToken = default)
     {
         if (limit is < 1 or > 500)
             throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be between 1 and 500.");
@@ -94,7 +94,7 @@ internal sealed class McpClusterSession(
         var resourceKind = ResolveResourceKind(cluster, workspace, apiVersion, kind);
         if (!cluster.ModelCatalog.Contains(resourceKind))
             throw new InvalidOperationException($"Unable to resolve Kubernetes resource for {apiVersion}/{kind}.");
-        await workspace.GetResourceConfig(resourceKind).SeedResource(waitForReady: true).ConfigureAwait(false);
+        await workspace.GetResourceConfig(resourceKind).SeedResource(waitForReady: true, cancellationToken: cancellationToken).ConfigureAwait(false);
         if (!cluster.Objects.TryGetValue(resourceKind, out var value)
             || value is not IResourceContainer container)
             return [];
@@ -107,20 +107,20 @@ internal sealed class McpClusterSession(
     }
 
     public async Task<IReadOnlyList<McpRelatedResourceInfo>> ListRelatedResourcesAsync(
-        string? clusterName, string apiVersion, string kind, string name, string? @namespace, int limit)
+        string? clusterName, string apiVersion, string kind, string name, string? @namespace, int limit, CancellationToken cancellationToken = default)
     {
-        var graph = await BuildResourceGraphAsync(clusterName, apiVersion, kind, name, @namespace, limit).ConfigureAwait(false);
+        var graph = await BuildResourceGraphAsync(clusterName, apiVersion, kind, name, @namespace, limit, cancellationToken).ConfigureAwait(false);
         return graph.Relationships;
     }
 
     public async Task<McpResourceGraphInfo> GetResourceGraphAsync(
-        string? clusterName, string apiVersion, string kind, string name, string? @namespace, int limit)
+        string? clusterName, string apiVersion, string kind, string name, string? @namespace, int limit, CancellationToken cancellationToken = default)
     {
-        return await BuildResourceGraphAsync(clusterName, apiVersion, kind, name, @namespace, limit).ConfigureAwait(false);
+        return await BuildResourceGraphAsync(clusterName, apiVersion, kind, name, @namespace, limit, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<McpResourceGraphInfo> BuildResourceGraphAsync(
-        string? clusterName, string apiVersion, string kind, string name, string? @namespace, int limit)
+        string? clusterName, string apiVersion, string kind, string name, string? @namespace, int limit, CancellationToken cancellationToken)
     {
         if (limit is < 1 or > 500)
             throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be between 1 and 500.");
@@ -131,7 +131,7 @@ internal sealed class McpClusterSession(
         var resourceKind = ResolveResourceKind(cluster, workspace, apiVersion, kind);
         if (!cluster.ModelCatalog.Contains(resourceKind))
             throw new InvalidOperationException($"Unable to resolve Kubernetes resource for {apiVersion}/{kind}.");
-        await workspace.GetResourceConfig(resourceKind).SeedResource(waitForReady: true).ConfigureAwait(false);
+        await workspace.GetResourceConfig(resourceKind).SeedResource(waitForReady: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var resources = cluster.Objects.Values
             .OfType<IResourceContainer>()

--- a/src/KubeUI.Avalonia/Infrastructure/Mcp/McpTools.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/Mcp/McpTools.cs
@@ -48,9 +48,9 @@ public sealed class McpTools(
 
     [McpServerTool(Name = "kubeui_list_resources", Title = "List Kubernetes resources", Destructive = false, ReadOnly = true, Idempotent = true), Description("Lists cached Kubernetes resources known to KubeUI. Call kubeui_list_supported_resources first and pass its FullApiVersion exactly, including the API group for non-core resources.")]
     public async Task<IReadOnlyList<McpResourceInfo>> ListResources(
-        string? cluster, string apiVersion, string kind, string? @namespace = null, int limit = 100)
+        string? cluster, string apiVersion, string kind, string? @namespace = null, int limit = 100, CancellationToken cancellationToken = default)
     {
-        var resources = await clusterSession.ListResourcesAsync(cluster, apiVersion, kind, @namespace, limit).ConfigureAwait(false);
+        var resources = await clusterSession.ListResourcesAsync(cluster, apiVersion, kind, @namespace, limit, cancellationToken).ConfigureAwait(false);
         return [.. resources.Select(resource => new McpResourceInfo(
             apiVersion, kind, resource.Metadata?.Name ?? string.Empty,
             resource.Metadata?.NamespaceProperty,
@@ -58,18 +58,18 @@ public sealed class McpTools(
     }
 
     [McpServerTool(Name = "kubeui_list_events", Title = "List Kubernetes events", Destructive = false, ReadOnly = true, Idempotent = true), Description("Lists Kubernetes Events cached by KubeUI.")]
-    public Task<IReadOnlyList<McpResourceInfo>> ListEvents(string? cluster = null, string? @namespace = null, int limit = 100)
-        => ListResources(cluster, "v1", "Event", @namespace, limit);
+    public Task<IReadOnlyList<McpResourceInfo>> ListEvents(string? cluster = null, string? @namespace = null, int limit = 100, CancellationToken cancellationToken = default)
+        => ListResources(cluster, "v1", "Event", @namespace, limit, cancellationToken);
 
     [McpServerTool(Name = "kubeui_related_resources", Title = "List related Kubernetes resources", Destructive = false, ReadOnly = true, Idempotent = true), Description("Lists resources directly related to a Kubernetes resource through KubeUI's relationship model.")]
     public Task<IReadOnlyList<McpRelatedResourceInfo>> ListRelatedResources(
-        string? cluster, string apiVersion, string kind, string name, string? @namespace = null, int limit = 100)
-        => clusterSession.ListRelatedResourcesAsync(cluster, apiVersion, kind, name, @namespace, limit);
+        string? cluster, string apiVersion, string kind, string name, string? @namespace = null, int limit = 100, CancellationToken cancellationToken = default)
+        => clusterSession.ListRelatedResourcesAsync(cluster, apiVersion, kind, name, @namespace, limit, cancellationToken);
 
     [McpServerTool(Name = "kubeui_resource_graph", Title = "Show Kubernetes resource graph", Destructive = false, ReadOnly = true, Idempotent = true), Description("Returns the selected Kubernetes resource and its directly related resources.")]
     public Task<McpResourceGraphInfo> GetResourceGraph(
-        string? cluster, string apiVersion, string kind, string name, string? @namespace = null, int limit = 100)
-        => clusterSession.GetResourceGraphAsync(cluster, apiVersion, kind, name, @namespace, limit);
+        string? cluster, string apiVersion, string kind, string name, string? @namespace = null, int limit = 100, CancellationToken cancellationToken = default)
+        => clusterSession.GetResourceGraphAsync(cluster, apiVersion, kind, name, @namespace, limit, cancellationToken);
 
     [McpServerTool(Name = "kubeui_diff_resource_yaml", Title = "Compare resource YAML", Destructive = false, ReadOnly = true, Idempotent = true), Description("Compares a live KubeUI resource YAML document with a proposed YAML document.")]
     public async Task<string> DiffResourceYaml(
@@ -99,7 +99,7 @@ public sealed class McpTools(
     }
 
     [McpServerTool(Name = "kubeui_get_resource_yaml", Title = "Get resource YAML", Destructive = false, ReadOnly = true, Idempotent = true), Description("Gets a Kubernetes resource as YAML.")]
-    public async Task<string> GetResourceYaml(string? cluster, string apiVersion, string kind, string name, string? @namespace = null)
+    public async Task<string> GetResourceYaml(string? cluster, string apiVersion, string kind, string name, string? @namespace = null, CancellationToken cancellationToken = default)
     {
         if (string.Equals(kind, "Secret", StringComparison.OrdinalIgnoreCase))
         {
@@ -112,7 +112,7 @@ public sealed class McpTools(
         var runtime = await clusterSession.GetConnectedClusterAsync(cluster).ConfigureAwait(false);
         if (!runtime.ModelCatalog.TryGetResourceKind(apiVersion, kind, out var resourceKind))
             throw new InvalidOperationException($"Unable to resolve Kubernetes resource for {apiVersion}/{kind}.");
-        await clusterSession.SeedResourceAsync(cluster, resourceKind).ConfigureAwait(false);
+        await clusterSession.SeedResourceAsync(cluster, resourceKind, cancellationToken).ConfigureAwait(false);
         var resource = runtime.Objects.TryGetValue(resourceKind, out var container)
             && container is IResourceContainer resourceContainer
             ? resourceContainer.Snapshot().FirstOrDefault(item =>

--- a/src/KubeUI.Avalonia/Resources/IResourceConfig.cs
+++ b/src/KubeUI.Avalonia/Resources/IResourceConfig.cs
@@ -35,6 +35,8 @@ namespace KubeUI.Avalonia.Resources
         }
         Task EvaluateListWatchAccessAsync();
         Task SeedResource(bool waitForReady = false);
+        Task SeedResource(bool waitForReady, CancellationToken cancellationToken)
+            => SeedResource(waitForReady);
         IRelayCommand NewResourceCommand { get; }
         IRelayCommand<IList> ViewCommand { get; }
         IAsyncRelayCommand<IList> DeleteCommand { get; }

--- a/src/KubeUI.Avalonia/Resources/ResourceConfigBase.cs
+++ b/src/KubeUI.Avalonia/Resources/ResourceConfigBase.cs
@@ -64,10 +64,13 @@ public abstract partial class ResourceConfigBase<T> : ObservableObject, IResourc
     public bool PermissionsLoaded { get; protected set; }
 
     public Task SeedResource(bool waitForReady = false)
+        => SeedResource(waitForReady, CancellationToken.None);
+
+    public Task SeedResource(bool waitForReady, CancellationToken cancellationToken)
     {
         return IsCustomResource
-            ? Cluster.Runtime.SeedResource(Kind, waitForReady)
-            : Cluster.Runtime.SeedResource<T>(waitForReady);
+            ? Cluster.Runtime.SeedResource(Kind, waitForReady, cancellationToken)
+            : Cluster.Runtime.SeedResource<T>(waitForReady, cancellationToken);
     }
 
     public virtual int Order { get; }
@@ -243,7 +246,7 @@ public abstract partial class ResourceConfigBase<T> : ObservableObject, IResourc
             Cluster.Runtime.ModelCatalog.RegisterResource(
                 Kind,
                 typeof(T),
-                waitForReady => Cluster.Runtime.SeedResource<T>(waitForReady));
+                (waitForReady, cancellationToken) => Cluster.Runtime.SeedResource<T>(waitForReady, cancellationToken));
         }
     }
 

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodContainerCellView.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodContainerCellView.cs
@@ -20,6 +20,7 @@ public partial class PodContainerCellView : ViewBase<V1Pod>, IInitializeCluster
     private V1Pod? _viewModel;
 
     private GroupApiVersionKind _groupApiVersionKind = GroupApiVersionKind.From<V1Pod>();
+    private bool _isSubscribed;
 
     [GeneratedDirectProperty]
     public partial ObservableCollection<ContainerStatusViewModel> ContainerStatuses { get; set; } = [];
@@ -128,7 +129,13 @@ public partial class PodContainerCellView : ViewBase<V1Pod>, IInitializeCluster
     protected override void OnUnloaded(RoutedEventArgs e)
     {
         base.OnUnloaded(e);
-        Cluster?.Runtime.OnChange -= _cluster_OnChange;
+        UnsubscribeFromCluster();
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        SubscribeToCluster();
     }
 
     private void PopulateData()
@@ -247,8 +254,27 @@ public partial class PodContainerCellView : ViewBase<V1Pod>, IInitializeCluster
 
     public void Initialize(ClusterWorkspace cluster)
     {
+        UnsubscribeFromCluster();
         Cluster = cluster;
-        Cluster.Runtime.OnChange += _cluster_OnChange;
+        SubscribeToCluster();
+    }
+
+    private void SubscribeToCluster()
+    {
+        if (!_isSubscribed && Cluster != null)
+        {
+            Cluster.Runtime.OnChange += _cluster_OnChange;
+            _isSubscribed = true;
+        }
+    }
+
+    private void UnsubscribeFromCluster()
+    {
+        if (_isSubscribed && Cluster != null)
+        {
+            Cluster.Runtime.OnChange -= _cluster_OnChange;
+            _isSubscribed = false;
+        }
     }
 
     public sealed partial class ContainerStatusViewModel : ObservableObject

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodContainerCellView.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodContainerCellView.cs
@@ -252,11 +252,18 @@ public partial class PodContainerCellView : ViewBase<V1Pod>, IInitializeCluster
         }
     }
 
+    /// <summary>
+    /// Initializes this cell with its cluster. Runtime change subscriptions start when the cell is attached.
+    /// Reinitialization replaces the previous cluster subscription when the cell is attached.
+    /// </summary>
     public void Initialize(ClusterWorkspace cluster)
     {
         UnsubscribeFromCluster();
         Cluster = cluster;
-        SubscribeToCluster();
+        if (VisualRoot != null)
+        {
+            SubscribeToCluster();
+        }
     }
 
     private void SubscribeToCluster()

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodStatusCellView.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodStatusCellView.cs
@@ -68,11 +68,18 @@ public sealed class PodStatusCellView : RefreshingCellTextBlock, IInitializeClus
         }
     }
 
+    /// <summary>
+    /// Initializes this cell with its cluster. Runtime change subscriptions start when the cell is attached.
+    /// Reinitialization replaces the previous cluster subscription when the cell is attached.
+    /// </summary>
     public void Initialize(ClusterWorkspace cluster)
     {
         UnsubscribeFromCluster();
         Cluster = cluster;
-        SubscribeToCluster();
+        if (VisualRoot != null)
+        {
+            SubscribeToCluster();
+        }
     }
 
     private void SubscribeToCluster()

--- a/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodStatusCellView.cs
+++ b/src/KubeUI.Avalonia/Resources/Workloads/v1/Pod/PodStatusCellView.cs
@@ -16,6 +16,7 @@ public sealed class PodStatusCellView : RefreshingCellTextBlock, IInitializeClus
     private V1Pod? _viewModel;
 
     private GroupApiVersionKind _groupApiVersionKind = GroupApiVersionKind.From<V1Pod>();
+    private bool _isSubscribed;
 
     public PodStatusCellView()
         : base(null)
@@ -50,7 +51,13 @@ public sealed class PodStatusCellView : RefreshingCellTextBlock, IInitializeClus
     protected override void OnUnloaded(RoutedEventArgs e)
     {
         base.OnUnloaded(e);
-        Cluster?.Runtime.OnChange -= _cluster_OnChange;
+        UnsubscribeFromCluster();
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        SubscribeToCluster();
     }
 
     private void _cluster_OnChange(WatchEventType eventType, GroupApiVersionKind groupApiVersionKind, IKubernetesObject<V1ObjectMeta> resource)
@@ -63,7 +70,26 @@ public sealed class PodStatusCellView : RefreshingCellTextBlock, IInitializeClus
 
     public void Initialize(ClusterWorkspace cluster)
     {
+        UnsubscribeFromCluster();
         Cluster = cluster;
-        Cluster.Runtime.OnChange += _cluster_OnChange;
+        SubscribeToCluster();
+    }
+
+    private void SubscribeToCluster()
+    {
+        if (!_isSubscribed && Cluster != null)
+        {
+            Cluster.Runtime.OnChange += _cluster_OnChange;
+            _isSubscribed = true;
+        }
+    }
+
+    private void UnsubscribeFromCluster()
+    {
+        if (_isSubscribed && Cluster != null)
+        {
+            Cluster.Runtime.OnChange -= _cluster_OnChange;
+            _isSubscribed = false;
+        }
     }
 }

--- a/src/KubeUI.Kubernetes/Client/Cluster.cs
+++ b/src/KubeUI.Kubernetes/Client/Cluster.cs
@@ -285,7 +285,10 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
         _logger.LogInformation("Disconnected from {name}", Name);
     }
 
-    public async Task SeedResource<T>(bool waitForReady = false) where T : class, IKubernetesObject<V1ObjectMeta>, new()
+    public Task SeedResource<T>(bool waitForReady = false) where T : class, IKubernetesObject<V1ObjectMeta>, new()
+        => SeedResource<T>(waitForReady, CancellationToken.None);
+
+    public async Task SeedResource<T>(bool waitForReady, CancellationToken cancellationToken) where T : class, IKubernetesObject<V1ObjectMeta>, new()
     {
         using var activity = StartClusterActivity(nameof(SeedResource) + "<" + typeof(T).Name + ">");
 
@@ -293,7 +296,7 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
         ModelCatalog.RegisterResource(
             kind,
             typeof(T),
-            waitForReady => SeedResource<T>(waitForReady));
+            (waitForReady, token) => SeedResource<T>(waitForReady, token));
         var container = (ContainerClass<T>)Objects.GetOrAdd(kind, _ => new ContainerClass<T>());
         var informerCancellationToken = GetResourceInformerCancellationToken();
         var seedTask = container.GetOrCreateSeedTask(() =>
@@ -303,7 +306,7 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
 
         try
         {
-            await seedTask.Value.ConfigureAwait(false);
+            await seedTask.Value.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -315,7 +318,8 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
         if (waitForReady)
         {
             _logger.LogDebug("Waiting for resource readiness for {type}.", typeof(T));
-            await IsResourceReady<T>(informerCancellationToken).ConfigureAwait(false);
+            using var readinessCancellation = CreateReadinessToken(informerCancellationToken, cancellationToken);
+            await IsResourceReady<T>(readinessCancellation?.Token ?? informerCancellationToken).ConfigureAwait(false);
             _logger.LogDebug("Resource readiness reached for {type}.", typeof(T));
         }
 
@@ -325,7 +329,10 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
         }
     }
 
-    public async Task SeedResource(GroupApiVersionKind kind, bool waitForReady = false)
+    public Task SeedResource(GroupApiVersionKind kind, bool waitForReady = false)
+        => SeedResource(kind, waitForReady, CancellationToken.None);
+
+    public async Task SeedResource(GroupApiVersionKind kind, bool waitForReady, CancellationToken cancellationToken)
     {
         if (!ModelCatalog.IsCustomResource(kind))
         {
@@ -334,7 +341,7 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
                 throw new ArgumentException($"Unknown resource kind {kind}.", nameof(kind));
             }
 
-            await seeder(waitForReady).ConfigureAwait(false);
+            await seeder(waitForReady, cancellationToken).ConfigureAwait(false);
             return;
         }
 
@@ -358,7 +365,8 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
 
             var informerCancellationToken = GetResourceInformerCancellationToken();
             _resourceInformerTasks.Add(Task.Run(() => informer.RunInfinite(informerCancellationToken)));
-            await informer.ReadyAsync(informerCancellationToken).ConfigureAwait(false);
+            using var readinessCancellation = CreateReadinessToken(informerCancellationToken, cancellationToken);
+            await informer.ReadyAsync(readinessCancellation?.Token ?? informerCancellationToken).ConfigureAwait(false);
 
             if (container.IsSeeded)
             {
@@ -368,7 +376,7 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
 
         try
         {
-            await seedTask.Value.ConfigureAwait(false);
+            await seedTask.Value.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
         {
@@ -378,7 +386,9 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
 
         if (waitForReady)
         {
-            await IsResourceReady<GenericKubernetesObject>(kind).ConfigureAwait(false);
+            var informerCancellationToken = GetResourceInformerCancellationToken();
+            using var readinessCancellation = CreateReadinessToken(informerCancellationToken, cancellationToken);
+            await IsResourceReady<GenericKubernetesObject>(kind, readinessCancellation?.Token ?? informerCancellationToken).ConfigureAwait(false);
         }
 
         if (!container.IsSeeded)
@@ -1016,6 +1026,15 @@ public sealed partial class Cluster : ObservableObject, IClusterRuntime, ICluste
     {
         EnsureResourceInformerCancellationTokenSource();
         return _resourceInformerCancellationTokenSource!.Token;
+    }
+
+    private static CancellationTokenSource? CreateReadinessToken(
+        CancellationToken informerCancellationToken,
+        CancellationToken requestCancellationToken)
+    {
+        return requestCancellationToken.CanBeCanceled
+            ? CancellationTokenSource.CreateLinkedTokenSource(informerCancellationToken, requestCancellationToken)
+            : null;
     }
 
     private void EnsureResourceInformerCancellationTokenSource()

--- a/src/KubeUI.Kubernetes/Client/ClusterModelCatalog.cs
+++ b/src/KubeUI.Kubernetes/Client/ClusterModelCatalog.cs
@@ -13,7 +13,7 @@ public sealed class ClusterModelCatalog
     private readonly Lock _gate = new();
     private readonly Dictionary<(string Group, string Version, string Kind), GroupApiVersionKind> _customResourceKinds = [];
     private readonly Dictionary<string, GroupApiVersionKind> _customResourceKindsByDefinitionName = new(StringComparer.Ordinal);
-    private readonly Dictionary<GroupApiVersionKind, Func<bool, Task>> _seeders = [];
+    private readonly Dictionary<GroupApiVersionKind, Func<bool, CancellationToken, Task>> _seeders = [];
 
     public KubernetesOpenApiSchemaCatalog OpenApiSchemas { get; } = new();
 
@@ -64,7 +64,7 @@ public sealed class ClusterModelCatalog
     /// <param name="resourceKind">API group, version, kind, and plural name.</param>
     /// <param name="resourceType">CLR model type used for the resource.</param>
     /// <param name="seeder">Operation that seeds the model and optionally waits for readiness.</param>
-    public void RegisterResource(GroupApiVersionKind resourceKind, Type resourceType, Func<bool, Task> seeder)
+    public void RegisterResource(GroupApiVersionKind resourceKind, Type resourceType, Func<bool, CancellationToken, Task> seeder)
     {
         ArgumentNullException.ThrowIfNull(seeder);
         RegisterResource(resourceKind, resourceType);
@@ -74,7 +74,7 @@ public sealed class ClusterModelCatalog
         }
     }
 
-    public bool TryGetResourceSeeder(GroupApiVersionKind resourceKind, out Func<bool, Task> seeder)
+    public bool TryGetResourceSeeder(GroupApiVersionKind resourceKind, out Func<bool, CancellationToken, Task> seeder)
     {
         lock (_gate)
         {

--- a/src/KubeUI.Kubernetes/Client/IClusterRuntime.cs
+++ b/src/KubeUI.Kubernetes/Client/IClusterRuntime.cs
@@ -46,7 +46,11 @@ public interface IClusterRuntime
     Task ImportFolder(string path);
     Task ImportYaml(Stream stream);
     Task SeedResource<T>(bool waitForReady = false) where T : class, IKubernetesObject<V1ObjectMeta>, new();
+    Task SeedResource<T>(bool waitForReady, CancellationToken cancellationToken) where T : class, IKubernetesObject<V1ObjectMeta>, new()
+        => SeedResource<T>(waitForReady);
     Task SeedResource(GroupApiVersionKind kind, bool waitForReady = false);
+    Task SeedResource(GroupApiVersionKind kind, bool waitForReady, CancellationToken cancellationToken)
+        => SeedResource(kind, waitForReady);
     Task<bool> IsResourceReady<T>(CancellationToken? token = null) where T : class, IKubernetesObject<V1ObjectMeta>, new();
     T? GetResource<T>(string? @namespace, string name) where T : class, IKubernetesObject<V1ObjectMeta>, new();
     IReadOnlyList<T> GetResourceList<T>() where T : class, IKubernetesObject<V1ObjectMeta>, new();

--- a/tests/KubeUI.Avalonia.Tests/Features/Clusters/Overview/ClusterViewTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Clusters/Overview/ClusterViewTests.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using KubeUI.Avalonia.Features.Clusters.Overview;
+using Shouldly;
+
+namespace KubeUI.Avalonia.Tests.Features.Clusters.Overview;
+
+public sealed class ClusterViewTests
+{
+    [AvaloniaFact]
+    public async Task cluster_view_restarts_refresh_timer_after_recycling()
+    {
+        var cluster = await Application.Current.CreateClusterAsync();
+        var viewModel = Application.Current.GetRequiredTestService<ClusterViewModel>();
+        viewModel.Initialize(cluster);
+
+        var view = new ClusterView { ViewModel = viewModel };
+        var window = new Window { Content = view };
+        window.Show();
+        await TestApplicationExtensions.WaitForUiAsync();
+
+        GetRefreshTimer(view).IsEnabled.ShouldBeTrue();
+
+        window.Content = null;
+        await TestApplicationExtensions.WaitForUiAsync();
+        GetRefreshTimer(view).IsEnabled.ShouldBeFalse();
+
+        window.Content = view;
+        await TestApplicationExtensions.WaitForUiAsync();
+
+        GetRefreshTimer(view).IsEnabled.ShouldBeTrue();
+        window.Close();
+    }
+
+    private static DispatcherTimer GetRefreshTimer(ClusterView view)
+    {
+        return ((DispatcherTimer?)typeof(ClusterView)
+            .GetField("_timer", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.GetValue(view)).ShouldNotBeNull();
+    }
+}

--- a/tests/KubeUI.Avalonia.Tests/Features/Clusters/Overview/ClusterViewTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Clusters/Overview/ClusterViewTests.cs
@@ -27,6 +27,11 @@ public sealed class ClusterViewTests
         await TestApplicationExtensions.WaitForUiAsync();
         GetRefreshTimer(view).IsEnabled.ShouldBeFalse();
 
+        view.DataContext = null;
+        view.DataContext = viewModel;
+        await TestApplicationExtensions.WaitForUiAsync();
+        GetRefreshTimer(view).IsEnabled.ShouldBeFalse();
+
         window.Content = view;
         await TestApplicationExtensions.WaitForUiAsync();
 

--- a/tests/KubeUI.Avalonia.Tests/Features/Workloads/Pod/PodContainerCellTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Workloads/Pod/PodContainerCellTests.cs
@@ -2,14 +2,155 @@ using System.Globalization;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
+using Avalonia.Threading;
 using k8s.Models;
 using KubeUI.Avalonia.Converters;
+using KubeUI.Avalonia.Resources.Workloads.v1.Pod;
 using Shouldly;
 
 namespace KubeUI.Avalonia.Tests.Features.Workloads.Pod;
 
 public sealed class PodContainerCellTests
 {
+    [AvaloniaFact]
+    public async Task pod_container_cell_resubscribes_after_recycling()
+    {
+        var cluster = await Application.Current.CreateClusterAsync();
+        await cluster.Runtime.SeedResource<V1Pod>(true);
+
+        var pod = new V1Pod
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = "container-status-pod",
+                NamespaceProperty = "default",
+            },
+            Spec = new V1PodSpec
+            {
+                Containers = [new V1Container { Name = "app", Image = "app:latest" }],
+            },
+            Status = new V1PodStatus
+            {
+                ContainerStatuses =
+                [
+                    new V1ContainerStatus
+                    {
+                        Name = "app",
+                        State = new V1ContainerState { Running = new V1ContainerStateRunning() },
+                    },
+                ],
+            },
+        };
+        await cluster.Runtime.AddOrUpdateResource(pod);
+
+        var cell = new PodContainerCellView();
+        cell.Initialize(cluster);
+        cell.DataContext = pod;
+        var window = new Window { Content = cell };
+        window.Show();
+        await TestApplicationExtensions.WaitForUiAsync();
+
+        cell.ContainerStatuses.ShouldNotBeNull();
+        cell.ContainerStatuses.Single().Status.ShouldBe("Running");
+
+        window.Content = null;
+        await TestApplicationExtensions.WaitForUiAsync();
+        window.Content = cell;
+        await TestApplicationExtensions.WaitForUiAsync();
+
+        var updatedPod = new V1Pod
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = pod.Name(),
+                NamespaceProperty = pod.Namespace(),
+                Uid = pod.Metadata!.Uid,
+            },
+            Spec = pod.Spec,
+            Status = new V1PodStatus
+            {
+                ContainerStatuses =
+                [
+                    new V1ContainerStatus
+                    {
+                        Name = "app",
+                        State = new V1ContainerState
+                        {
+                            Waiting = new V1ContainerStateWaiting { Reason = "ImagePullBackOff" },
+                        },
+                    },
+                ],
+            },
+        };
+        await cluster.Runtime.AddOrUpdateResource(updatedPod);
+
+        await TestWait.UntilAsync(
+            () => cell.ContainerStatuses.Single().Status == "ImagePullBackOff",
+            5000,
+            TestContext.Current.CancellationToken,
+            () => Dispatcher.UIThread.RunJobs());
+
+        cell.ContainerStatuses.Single().Status.ShouldBe("ImagePullBackOff");
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public async Task pod_status_cell_resubscribes_after_recycling()
+    {
+        var cluster = await Application.Current.CreateClusterAsync();
+        await cluster.Runtime.SeedResource<V1Pod>(true);
+
+        var pod = new V1Pod
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = "status-pod",
+                NamespaceProperty = "default",
+            },
+            Status = new V1PodStatus
+            {
+                Conditions = [new V1PodCondition { Type = "Ready", Status = "True" }],
+            },
+        };
+        await cluster.Runtime.AddOrUpdateResource(pod);
+
+        var cell = new PodStatusCellView();
+        cell.Initialize(cluster);
+        cell.DataContext = pod;
+        var window = new Window { Content = cell };
+        window.Show();
+        await TestApplicationExtensions.WaitForUiAsync();
+
+        cell.Text.ShouldBe(Assets.Resources.PodStatusCell_Running);
+
+        window.Content = null;
+        await TestApplicationExtensions.WaitForUiAsync();
+        window.Content = cell;
+        await TestApplicationExtensions.WaitForUiAsync();
+
+        var terminatingPod = new V1Pod
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = pod.Name(),
+                NamespaceProperty = pod.Namespace(),
+                Uid = pod.Metadata!.Uid,
+                DeletionTimestamp = DateTime.UtcNow,
+            },
+            Status = pod.Status,
+        };
+        await cluster.Runtime.AddOrUpdateResource(terminatingPod);
+
+        await TestWait.UntilAsync(
+            () => cell.Text == Assets.Resources.PodStatusCell_Terminating,
+            5000,
+            TestContext.Current.CancellationToken,
+            () => Dispatcher.UIThread.RunJobs());
+
+        cell.Text.ShouldBe(Assets.Resources.PodStatusCell_Terminating);
+        window.Close();
+    }
+
     [AvaloniaFact]
     public void container_status_brush_resolves_from_application_theme_resources()
     {

--- a/tests/KubeUI.Avalonia.Tests/Features/Workloads/Pod/PodContainerCellTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Workloads/Pod/PodContainerCellTests.cs
@@ -13,6 +13,44 @@ namespace KubeUI.Avalonia.Tests.Features.Workloads.Pod;
 public sealed class PodContainerCellTests
 {
     [AvaloniaFact]
+    public async Task pod_container_cell_initialize_replaces_cluster_subscription()
+    {
+        var firstCluster = await Application.Current.CreateClusterAsync();
+        var secondCluster = await Application.Current.CreateClusterAsync();
+        await firstCluster.Runtime.SeedResource<V1Pod>(true);
+        await secondCluster.Runtime.SeedResource<V1Pod>(true);
+
+        var firstPod = CreateContainerPod("replace-subscription-pod", "Running");
+        var secondPod = CreateContainerPod("replace-subscription-pod", "Running");
+        await firstCluster.Runtime.AddOrUpdateResource(firstPod);
+        await secondCluster.Runtime.AddOrUpdateResource(secondPod);
+
+        var cell = new PodContainerCellView();
+        cell.Initialize(firstCluster);
+        cell.DataContext = firstPod;
+        var window = new Window { Content = cell };
+        window.Show();
+        await TestApplicationExtensions.WaitForUiAsync();
+
+        cell.Initialize(secondCluster);
+
+        await firstCluster.Runtime.AddOrUpdateResource(CreateContainerPod(
+            "replace-subscription-pod", "ImagePullBackOff", firstPod.Metadata!.Uid));
+        await TestApplicationExtensions.WaitForUiAsync();
+        cell.ContainerStatuses.Single().Status.ShouldBe("Running");
+
+        await secondCluster.Runtime.AddOrUpdateResource(CreateContainerPod(
+            "replace-subscription-pod", "ImagePullBackOff", secondPod.Metadata!.Uid));
+        await TestWait.UntilAsync(
+            () => cell.ContainerStatuses.Single().Status == "ImagePullBackOff",
+            5000,
+            TestContext.Current.CancellationToken,
+            () => Dispatcher.UIThread.RunJobs());
+
+        window.Close();
+    }
+
+    [AvaloniaFact]
     public async Task pod_container_cell_resubscribes_after_recycling()
     {
         var cluster = await Application.Current.CreateClusterAsync();
@@ -55,8 +93,6 @@ public sealed class PodContainerCellTests
 
         window.Content = null;
         await TestApplicationExtensions.WaitForUiAsync();
-        window.Content = cell;
-        await TestApplicationExtensions.WaitForUiAsync();
 
         var updatedPod = new V1Pod
         {
@@ -82,6 +118,12 @@ public sealed class PodContainerCellTests
                 ],
             },
         };
+        await cluster.Runtime.AddOrUpdateResource(updatedPod);
+        await TestApplicationExtensions.WaitForUiAsync();
+        cell.ContainerStatuses.Single().Status.ShouldBe("Running");
+
+        window.Content = cell;
+        await TestApplicationExtensions.WaitForUiAsync();
         await cluster.Runtime.AddOrUpdateResource(updatedPod);
 
         await TestWait.UntilAsync(
@@ -125,8 +167,6 @@ public sealed class PodContainerCellTests
 
         window.Content = null;
         await TestApplicationExtensions.WaitForUiAsync();
-        window.Content = cell;
-        await TestApplicationExtensions.WaitForUiAsync();
 
         var terminatingPod = new V1Pod
         {
@@ -140,6 +180,12 @@ public sealed class PodContainerCellTests
             Status = pod.Status,
         };
         await cluster.Runtime.AddOrUpdateResource(terminatingPod);
+        await TestApplicationExtensions.WaitForUiAsync();
+        cell.Text.ShouldBe(Assets.Resources.PodStatusCell_Running);
+
+        window.Content = cell;
+        await TestApplicationExtensions.WaitForUiAsync();
+        await cluster.Runtime.AddOrUpdateResource(terminatingPod);
 
         await TestWait.UntilAsync(
             () => cell.Text == Assets.Resources.PodStatusCell_Terminating,
@@ -149,6 +195,36 @@ public sealed class PodContainerCellTests
 
         cell.Text.ShouldBe(Assets.Resources.PodStatusCell_Terminating);
         window.Close();
+    }
+
+    private static V1Pod CreateContainerPod(string name, string status, string? uid = null)
+    {
+        return new V1Pod
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = name,
+                NamespaceProperty = "default",
+                Uid = uid,
+            },
+            Spec = new V1PodSpec
+            {
+                Containers = [new V1Container { Name = "app", Image = "app:latest" }],
+            },
+            Status = new V1PodStatus
+            {
+                ContainerStatuses =
+                [
+                    new V1ContainerStatus
+                    {
+                        Name = "app",
+                        State = status == "Running"
+                            ? new V1ContainerState { Running = new V1ContainerStateRunning() }
+                            : new V1ContainerState { Waiting = new V1ContainerStateWaiting { Reason = status } },
+                    },
+                ],
+            },
+        };
     }
 
     [AvaloniaFact]

--- a/tests/KubeUI.Avalonia.Tests/Infrastructure/Mcp/McpClusterSessionTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Infrastructure/Mcp/McpClusterSessionTests.cs
@@ -8,6 +8,18 @@ namespace KubeUI.Avalonia.Tests.Infrastructure.Mcp;
 public sealed class McpClusterSessionTests
 {
     [AvaloniaFact]
+    public async Task list_resources_honors_request_cancellation_during_resource_readiness()
+    {
+        var workspace = await Application.Current.CreateClusterAsync();
+        var session = Application.Current.GetTestServices().GetRequiredService<IMcpClusterSession>();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(() => session.ListResourcesAsync(
+            workspace.Runtime.Name, "v1", "Pod", "default", 10, cancellation.Token));
+    }
+
+    [AvaloniaFact]
     public async Task list_resources_uses_the_real_kubeui_workspace_cache_and_namespace_filter()
     {
         var pod = new V1Pod


### PR DESCRIPTION
…Pod and Cluster views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cluster overviews now resume automatic refresh when views are reattached.
  - Pod container and status cells continue receiving live updates after being recycled or reloaded.
  - Improved lifecycle handling prevents stale or duplicate update subscriptions.
  - Cluster resource views now wait for resources to be ready before displaying seeded data.

- **Tests**
  - Added coverage for refresh recovery and continued pod status updates after view recycling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->