### PR TITLE
fix: ResourceGraphControl lag and refactor AI Chat

### DIFF
--- a/src/KubeUI.AI/AGENTS.md
+++ b/src/KubeUI.AI/AGENTS.md
@@ -5,3 +5,7 @@
 - Treat agent runtimes as configurable processes; never hardcode runtime-specific behavior into the transport.
 - Keep prompts, responses, credentials, kubeconfigs, and Kubernetes Secret contents out of telemetry by default.
 - Add adapter and mapping tests for every supported ACP union or update variant.
+- Gate HTTP MCP session entries on the agent's negotiated HTTP MCP capability.
+- Treat ACP file line numbers as 1-based and enforce configured `AgentSessionOptions.FileSystemRoots`.
+- Terminal output limits retain newest output, omit exit status until process exit, and observe capture-task failures during release and disposal.
+- Unsupported ACP extension methods and notifications fail explicitly; fake ACP tests remain external-process free.

--- a/src/KubeUI.AI/Acp/AcpAgent.cs
+++ b/src/KubeUI.AI/Acp/AcpAgent.cs
@@ -47,7 +47,7 @@ public sealed class AcpAgent : IAgent
         try
         {
             await process.StartAsync(cancellationToken).ConfigureAwait(false);
-            client = new DotAcpClient(events.Writer, _permissionService, options.TrustedMcpServers);
+            client = new DotAcpClient(events.Writer, _permissionService, options.TrustedMcpServers, options.FileSystemRoots);
             connection = Connection.RunClient(client, process.Input, process.Output)
                 ?? throw new InvalidOperationException("Unable to create ACP connection.");
             ProtocolInitializeResponse initialize;
@@ -57,7 +57,7 @@ public sealed class AcpAgent : IAgent
                 initializeActivity?.SetTag("agent.protocol", "acp");
                 initialize = await connection.InitializeAsync(new InitializeRequest
                 {
-                    ProtocolVersion = 1,
+                    ProtocolVersion = ProtocolMeta.Version,
                     ClientInfo = new Implementation { Name = "KubeUI", Version = "1.0" },
                     ClientCapabilities = new ClientCapabilities
                     {
@@ -87,6 +87,7 @@ public sealed class AcpAgent : IAgent
                 {
                     Cwd = options.WorkingDirectory ?? Environment.CurrentDirectory,
                     McpServers = string.IsNullOrWhiteSpace(options.McpEndpoint)
+                        || initialize.AgentCapabilities?.McpCapabilities?.Http != true
                         ? []
                         : [new McpServerHttp { Name = "kubeui", Url = options.McpEndpoint, Headers = [] }]
                 }, cancellationToken).ConfigureAwait(false);
@@ -99,8 +100,7 @@ public sealed class AcpAgent : IAgent
                 events,
                 options.Context,
                 process,
-                client,
-                null);
+                client);
         }
         catch (Exception exception)
         {
@@ -150,7 +150,7 @@ public sealed class AcpAgent : IAgent
             | DomainAgentCapabilities.Permissions
             | DomainAgentCapabilities.Plans
             | DomainAgentCapabilities.Usage;
-        if (result.AgentCapabilities?.McpCapabilities != null)
+        if (result.AgentCapabilities?.McpCapabilities?.Http == true)
             capabilities |= DomainAgentCapabilities.Mcp;
         return capabilities;
     }

--- a/src/KubeUI.AI/Acp/AcpAgentSession.cs
+++ b/src/KubeUI.AI/Acp/AcpAgentSession.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Threading.Channels;
 using dotacp.client;
 using dotacp.protocol;
@@ -15,7 +16,6 @@ internal sealed class AcpAgentSession : IAgentSession
     private readonly Channel<AgentEvent> _events;
     private readonly IAcpProcess? _diagnosticProcess;
     private readonly IDisposable? _client;
-    private readonly Action? _onDispose;
     private bool _disposed;
 
     public AcpAgentSession(
@@ -25,8 +25,7 @@ internal sealed class AcpAgentSession : IAgentSession
         Channel<AgentEvent> events,
         AgentContext? context = null,
         IAcpProcess? diagnosticProcess = null,
-        IDisposable? client = null,
-        Action? onDispose = null)
+        IDisposable? client = null)
     {
         _id = id;
         _protocolId = protocolId;
@@ -35,7 +34,6 @@ internal sealed class AcpAgentSession : IAgentSession
         _events = events;
         _diagnosticProcess = diagnosticProcess;
         _client = client;
-        _onDispose = onDispose;
         if (_diagnosticProcess is not null)
             _diagnosticProcess.ErrorReceived += DiagnosticProcessOnError;
         if (_diagnosticProcess is not null)
@@ -88,10 +86,18 @@ internal sealed class AcpAgentSession : IAgentSession
             _diagnosticProcess.ErrorReceived -= DiagnosticProcessOnError;
             _diagnosticProcess.Exited -= ProcessOnExited;
         }
-        _onDispose?.Invoke();
         using var activity = AgentActivitySource.Source.StartActivity("ai.agent.stop");
         activity?.SetTag("agent.protocol", "acp");
         _connection.Dispose();
+        try
+        {
+            await _connection.Completion.ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
+            activity?.AddException(exception);
+        }
         _client?.Dispose();
         if (_diagnosticProcess is not null)
             await _diagnosticProcess.DisposeAsync().ConfigureAwait(false);

--- a/src/KubeUI.AI/Acp/AcpFileSystemHandler.cs
+++ b/src/KubeUI.AI/Acp/AcpFileSystemHandler.cs
@@ -64,9 +64,40 @@ internal sealed class AcpFileSystemHandler(
         var comparison = OperatingSystem.IsWindows()
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
-        if (_fileSystemRoots.Any(root => IsWithinRoot(fullPath, root, comparison)))
+        if (_fileSystemRoots.Any(root => IsWithinRoot(fullPath, root, comparison)
+            && !ContainsReparsePoint(root, fullPath)))
             return;
         throw new UnauthorizedAccessException($"File path '{path}' is outside configured ACP filesystem roots.");
+    }
+
+    private static bool ContainsReparsePoint(string root, string path)
+    {
+        var relative = Path.GetRelativePath(root, path);
+        var current = root;
+        foreach (var component in relative.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = Path.Combine(current, component);
+            if (HasReparsePoint(current))
+                return true;
+        }
+
+        return HasReparsePoint(root);
+    }
+
+    private static bool HasReparsePoint(string path)
+    {
+        try
+        {
+            return File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint);
+        }
+        catch (FileNotFoundException)
+        {
+            return false;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return false;
+        }
     }
 
     private static bool IsWithinRoot(string path, string root, StringComparison comparison)

--- a/src/KubeUI.AI/Acp/AcpFileSystemHandler.cs
+++ b/src/KubeUI.AI/Acp/AcpFileSystemHandler.cs
@@ -1,0 +1,81 @@
+using dotacp.protocol;
+using KubeUI.AI.Agents;
+using KubeUI.AI.Permissions;
+
+namespace KubeUI.AI.Acp;
+
+internal sealed class AcpFileSystemHandler(
+    IAgentPermissionService permissionService,
+    IReadOnlySet<string>? fileSystemRoots = null)
+{
+    private readonly string[] _fileSystemRoots = fileSystemRoots is null
+        ? []
+        : fileSystemRoots.Select(Path.GetFullPath).ToArray();
+
+    public async Task<ReadTextFileResponse> ReadTextFileAsync(
+        ReadTextFileRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var permission = await permissionService.RequestPermissionAsync(
+            new AgentPermissionRequest("read_file", request.Path), cancellationToken).ConfigureAwait(false);
+        if (!permission.Allowed)
+            throw new UnauthorizedAccessException(permission.Reason ?? $"Reading '{request.Path}' was denied.");
+        EnsurePathAllowed(request.Path);
+
+        var start = request.Line is null ? 0 : checked((int)request.Line.Value - 1);
+        var limit = request.Limit is null ? int.MaxValue : checked((int)request.Limit.Value);
+        if (start < 0 || limit < 0)
+            return new ReadTextFileResponse { Content = string.Empty };
+
+        using var reader = File.OpenText(request.Path);
+        for (var index = 0; index < start; index++)
+        {
+            if (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is null)
+                return new ReadTextFileResponse { Content = string.Empty };
+        }
+
+        var selected = new List<string>(Math.Min(limit, 256));
+        while (selected.Count < limit
+            && await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
+            selected.Add(line);
+        return new ReadTextFileResponse { Content = string.Join('\n', selected) };
+    }
+
+    public async Task<WriteTextFileResponse> WriteTextFileAsync(
+        WriteTextFileRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var permission = await permissionService.RequestPermissionAsync(
+            new AgentPermissionRequest("write_file", request.Path, IsDestructive: true), cancellationToken).ConfigureAwait(false);
+        if (!permission.Allowed)
+            throw new UnauthorizedAccessException(permission.Reason ?? $"Writing '{request.Path}' was denied.");
+        EnsurePathAllowed(request.Path);
+
+        await File.WriteAllTextAsync(request.Path, request.Content, cancellationToken).ConfigureAwait(false);
+        return new WriteTextFileResponse();
+    }
+
+    private void EnsurePathAllowed(string path)
+    {
+        if (_fileSystemRoots.Length == 0)
+            return;
+
+        var fullPath = Path.GetFullPath(path);
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (_fileSystemRoots.Any(root => IsWithinRoot(fullPath, root, comparison)))
+            return;
+        throw new UnauthorizedAccessException($"File path '{path}' is outside configured ACP filesystem roots.");
+    }
+
+    private static bool IsWithinRoot(string path, string root, StringComparison comparison)
+    {
+        var relative = Path.GetRelativePath(root, path);
+        return relative == "."
+            || (!Path.IsPathRooted(relative)
+                && !string.Equals(relative, "..", comparison)
+                && !relative.StartsWith($"..{Path.DirectorySeparatorChar}", comparison)
+                && !relative.StartsWith($"..{Path.AltDirectorySeparatorChar}", comparison));
+    }
+}

--- a/src/KubeUI.AI/Acp/AcpMapper.cs
+++ b/src/KubeUI.AI/Acp/AcpMapper.cs
@@ -35,8 +35,9 @@ internal static class AcpMapper
         if (!IsMcpTool(meta))
             return null;
 
-        var inputObject = JsonConvert.SerializeObject(input);
-        var inputJson = JObject.Parse(inputObject);
+        var inputJson = ParseObject(input);
+        if (inputJson is null)
+            return null;
         return inputJson["server"]?.Value<string>();
     }
 
@@ -45,14 +46,21 @@ internal static class AcpMapper
         if (meta?.TryGetValue("is_mcp_tool_call", out var marker) != true || !IsTrue(marker))
             return null;
 
-        var inputObject = JsonConvert.SerializeObject(input);
-        var inputJson = JObject.Parse(inputObject);
+        var inputJson = ParseObject(input);
+        if (inputJson is null)
+            return "MCP tool";
         var server = inputJson["server"]?.Value<string>();
         var tool = inputJson["tool"]?.Value<string>();
         if (string.IsNullOrWhiteSpace(server) || string.IsNullOrWhiteSpace(tool))
             return "MCP tool";
 
         return $"MCP {server}/{tool}";
+    }
+
+    private static JObject? ParseObject(object? input)
+    {
+        var serialized = JsonConvert.SerializeObject(input);
+        return JToken.Parse(serialized) as JObject;
     }
 
     private static bool IsTrue(object value) => value switch

--- a/src/KubeUI.AI/Acp/AcpMapper.cs
+++ b/src/KubeUI.AI/Acp/AcpMapper.cs
@@ -1,83 +1,11 @@
-using System.Text.Json;
 using dotacp.protocol;
 using KubeUI.AI.Agents;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace KubeUI.AI.Acp;
 
 internal static class AcpMapper
 {
-    public static AgentPermissionRequest ToPermissionRequest(
-        RequestPermissionRequest request,
-        string? knownTitle = null,
-        object? knownInput = null,
-        ToolKind? knownKind = null,
-        Dictionary<string, object>? knownMeta = null,
-        IReadOnlySet<string>? trustedMcpServers = null)
-    {
-        var title = request.ToolCall.Title ?? knownTitle;
-        var input = request.ToolCall.RawInput ?? knownInput;
-        var meta = request.ToolCall.Meta ?? knownMeta;
-        var action = string.IsNullOrWhiteSpace(title)
-            ? GetMcpToolAction(meta, input) ?? request.ToolCall.Kind.ToString()
-            : title;
-        var resource = Serialize(input);
-        var destructive = IsDestructive(knownKind ?? request.ToolCall.Kind, meta);
-        var mcpServer = GetMcpServer(meta, input);
-        var requiresApproval = destructive
-            || (mcpServer is not null && !(trustedMcpServers?.Contains(mcpServer) ?? false));
-        return new AgentPermissionRequest(action, resource, destructive, requiresApproval);
-    }
-
-    private static string? GetMcpServer(Dictionary<string, object>? meta, object? input)
-    {
-        if (!IsMcpTool(meta))
-            return null;
-
-        var inputJson = ParseObject(input);
-        if (inputJson is null)
-            return null;
-        return inputJson["server"]?.Value<string>();
-    }
-
-    private static string? GetMcpToolAction(Dictionary<string, object>? meta, object? input)
-    {
-        if (meta?.TryGetValue("is_mcp_tool_call", out var marker) != true || !IsTrue(marker))
-            return null;
-
-        var inputJson = ParseObject(input);
-        if (inputJson is null)
-            return "MCP tool";
-        var server = inputJson["server"]?.Value<string>();
-        var tool = inputJson["tool"]?.Value<string>();
-        if (string.IsNullOrWhiteSpace(server) || string.IsNullOrWhiteSpace(tool))
-            return "MCP tool";
-
-        return $"MCP {server}/{tool}";
-    }
-
-    private static JObject? ParseObject(object? input)
-    {
-        var serialized = JsonConvert.SerializeObject(input);
-        return JToken.Parse(serialized) as JObject;
-    }
-
-    private static bool IsTrue(object value) => value switch
-    {
-        bool boolean => boolean,
-        JsonElement element when element.ValueKind == JsonValueKind.True => true,
-        JValue token when token.Type == JTokenType.Boolean => token.Value<bool>(),
-        _ => bool.TryParse(value.ToString(), out var parsed) && parsed
-    };
-
-    private static bool IsDestructive(ToolKind kind, Dictionary<string, object>? meta)
-        => !IsMcpTool(meta)
-            && kind is (ToolKind.Edit or ToolKind.Delete or ToolKind.Move or ToolKind.Execute);
-
-    private static bool IsMcpTool(Dictionary<string, object>? meta)
-        => meta?.TryGetValue("is_mcp_tool_call", out var marker) == true && IsTrue(marker);
-
     public static AgentEvent? ToAgentEvent(SessionUpdate update)
     {
         switch (update)

--- a/src/KubeUI.AI/Acp/AcpPermissionHandler.cs
+++ b/src/KubeUI.AI/Acp/AcpPermissionHandler.cs
@@ -14,23 +14,47 @@ internal sealed class AcpPermissionHandler(
     IReadOnlySet<string>? trustedMcpServers = null)
 {
     private readonly IReadOnlySet<string> _trustedMcpServers = trustedMcpServers ?? new HashSet<string>(StringComparer.Ordinal);
+    private readonly AcpPermissionMapper _permissionMapper = new();
     private readonly ConcurrentDictionary<string, ToolCallContext> _toolCalls = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, byte> _startedToolCalls = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, byte> _completedToolCalls = new(StringComparer.Ordinal);
 
-    public void TrackToolCall(SessionUpdate update)
+    public bool TrackToolCall(SessionUpdate update)
     {
         switch (update)
         {
             case ToolCall toolCall:
-                _toolCalls[toolCall.ToolCallId.ToString()] = new(toolCall.Title, toolCall.RawInput, toolCall.Kind, toolCall.Meta);
-                break;
-            case SessionUpdateToolCallUpdate toolUpdate when _toolCalls.TryGetValue(toolUpdate.ToolCallId.ToString(), out var previous):
-                _toolCalls[toolUpdate.ToolCallId.ToString()] = new(
-                    toolUpdate.Title ?? previous.Title,
-                    toolUpdate.RawInput ?? previous.Input,
-                    toolUpdate.Kind,
-                    toolUpdate.Meta ?? previous.Meta);
-                break;
+                return TrackToolCall(
+                    toolCall.ToolCallId.ToString(),
+                    toolCall.Status,
+                    new(toolCall.Title, toolCall.RawInput, toolCall.Kind, toolCall.Meta));
+            case SessionUpdateToolCallUpdate toolUpdate:
+                var key = toolUpdate.ToolCallId.ToString();
+                _toolCalls.AddOrUpdate(
+                    key,
+                    _ => new(toolUpdate.Title, toolUpdate.RawInput, toolUpdate.Kind, toolUpdate.Meta),
+                    (_, previous) => new(
+                        toolUpdate.Title ?? previous.Title,
+                        toolUpdate.RawInput ?? previous.Input,
+                        toolUpdate.Kind,
+                        toolUpdate.Meta ?? previous.Meta));
+                return TrackToolCall(key, toolUpdate.Status, _toolCalls[key]);
+            default:
+                return true;
         }
+    }
+
+    private bool TrackToolCall(string key, ToolCallStatus status, ToolCallContext context)
+    {
+        if (status is ToolCallStatus.Completed or ToolCallStatus.Failed)
+        {
+            _toolCalls.TryRemove(key, out _);
+            _startedToolCalls.TryRemove(key, out _);
+            return _completedToolCalls.TryAdd(key, 0);
+        }
+
+        _toolCalls[key] = context;
+        return _startedToolCalls.TryAdd(key, 0);
     }
 
     public async Task<RequestPermissionResponse> RequestAsync(
@@ -41,7 +65,7 @@ internal sealed class AcpPermissionHandler(
         activity?.SetTag("agent.protocol", "acp");
         activity?.SetTag("permission.action", request.ToolCall.Title);
         _toolCalls.TryGetValue(request.ToolCall.ToolCallId.ToString(), out var knownTool);
-        var permissionRequest = AcpMapper.ToPermissionRequest(
+        var permissionRequest = _permissionMapper.Map(
             request,
             knownTool?.Title,
             knownTool?.Input,
@@ -52,8 +76,23 @@ internal sealed class AcpPermissionHandler(
             return SelectResponse(request, allowed: true, activity);
 
         events.TryWrite(new AgentPermissionRequestedEvent(permissionRequest));
-        var permission = await permissionService.RequestPermissionAsync(permissionRequest, cancellationToken).ConfigureAwait(false);
-        return SelectResponse(request, permission.Allowed, activity);
+        try
+        {
+            var permission = await permissionService.RequestPermissionAsync(permissionRequest, cancellationToken).ConfigureAwait(false);
+            return SelectResponse(request, permission.Allowed, activity);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            activity?.SetTag("permission.result", "cancelled");
+            return new RequestPermissionResponse { Outcome = new RequestPermissionOutcomeCancelled() };
+        }
+    }
+
+    public void Clear()
+    {
+        _toolCalls.Clear();
+        _startedToolCalls.Clear();
+        _completedToolCalls.Clear();
     }
 
     private static RequestPermissionResponse SelectResponse(

--- a/src/KubeUI.AI/Acp/AcpPermissionMapper.cs
+++ b/src/KubeUI.AI/Acp/AcpPermissionMapper.cs
@@ -24,9 +24,10 @@ internal sealed class AcpPermissionMapper
             ? GetMcpToolAction(meta, input) ?? request.ToolCall.Kind.ToString()
             : title;
         var destructive = IsDestructive(knownKind ?? request.ToolCall.Kind, meta);
+        var isMcpTool = IsMcpTool(meta);
         var mcpServer = GetMcpServer(meta, input);
         var requiresApproval = destructive
-            || (mcpServer is not null && !trustedMcpServers.Contains(mcpServer));
+            || (isMcpTool && (mcpServer is null || !trustedMcpServers.Contains(mcpServer)));
         return new AgentPermissionRequest(action, Serialize(input), destructive, requiresApproval);
     }
 

--- a/src/KubeUI.AI/Acp/AcpPermissionMapper.cs
+++ b/src/KubeUI.AI/Acp/AcpPermissionMapper.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+using dotacp.protocol;
+using KubeUI.AI.Agents;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace KubeUI.AI.Acp;
+
+// ACP permission policy. Runtime-specific metadata stays outside domain event mapping.
+internal sealed class AcpPermissionMapper
+{
+    public AgentPermissionRequest Map(
+        RequestPermissionRequest request,
+        string? knownTitle,
+        object? knownInput,
+        ToolKind? knownKind,
+        Dictionary<string, object>? knownMeta,
+        IReadOnlySet<string> trustedMcpServers)
+    {
+        var title = request.ToolCall.Title ?? knownTitle;
+        var input = request.ToolCall.RawInput ?? knownInput;
+        var meta = request.ToolCall.Meta ?? knownMeta;
+        var action = string.IsNullOrWhiteSpace(title)
+            ? GetMcpToolAction(meta, input) ?? request.ToolCall.Kind.ToString()
+            : title;
+        var destructive = IsDestructive(knownKind ?? request.ToolCall.Kind, meta);
+        var mcpServer = GetMcpServer(meta, input);
+        var requiresApproval = destructive
+            || (mcpServer is not null && !trustedMcpServers.Contains(mcpServer));
+        return new AgentPermissionRequest(action, Serialize(input), destructive, requiresApproval);
+    }
+
+    private static string? GetMcpServer(Dictionary<string, object>? meta, object? input)
+    {
+        if (!IsMcpTool(meta))
+            return null;
+        return ParseObject(input)?["server"]?.Value<string>();
+    }
+
+    private static string? GetMcpToolAction(Dictionary<string, object>? meta, object? input)
+    {
+        if (!IsMcpTool(meta))
+            return null;
+        var inputJson = ParseObject(input);
+        if (inputJson is null)
+            return "MCP tool";
+        var server = inputJson["server"]?.Value<string>();
+        var tool = inputJson["tool"]?.Value<string>();
+        return string.IsNullOrWhiteSpace(server) || string.IsNullOrWhiteSpace(tool)
+            ? "MCP tool"
+            : $"MCP {server}/{tool}";
+    }
+
+    private static JObject? ParseObject(object? input)
+    {
+        try
+        {
+            return JToken.Parse(JsonConvert.SerializeObject(input)) as JObject;
+        }
+        catch (Newtonsoft.Json.JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsTrue(object value) => value switch
+    {
+        bool boolean => boolean,
+        JsonElement element when element.ValueKind == JsonValueKind.True => true,
+        JValue token when token.Type == JTokenType.Boolean => token.Value<bool>(),
+        _ => bool.TryParse(value.ToString(), out var parsed) && parsed
+    };
+
+    private static bool IsDestructive(ToolKind kind, Dictionary<string, object>? meta)
+        => !IsMcpTool(meta)
+            && kind is (ToolKind.Edit or ToolKind.Delete or ToolKind.Move or ToolKind.Execute);
+
+    private static bool IsMcpTool(Dictionary<string, object>? meta)
+        => meta?.TryGetValue("is_mcp_tool_call", out var marker) == true && IsTrue(marker);
+
+    private static string? Serialize(object? value) => value is null ? null : JsonConvert.SerializeObject(value);
+}

--- a/src/KubeUI.AI/Acp/AcpProcess.cs
+++ b/src/KubeUI.AI/Acp/AcpProcess.cs
@@ -16,6 +16,7 @@ internal sealed class AcpProcess(AcpAgentDefinition definition, AgentSessionOpti
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var startInfo = new ProcessStartInfo
         {
             FileName = ExecutableLocator.Find(definition.Executable) ?? definition.Executable,
@@ -41,8 +42,26 @@ internal sealed class AcpProcess(AcpAgentDefinition definition, AgentSessionOpti
 
         _process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
         _process.Exited += ProcessOnExited;
-        if (!_process.Start())
-            throw new InvalidOperationException($"Unable to start ACP agent '{definition.Id}'.");
+        try
+        {
+            if (!_process.Start())
+                throw new InvalidOperationException($"Unable to start ACP agent '{definition.Id}'.");
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+        catch
+        {
+            try
+            {
+                if (_process.HasExited is false)
+                    _process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+            }
+            _process.Dispose();
+            _process = null;
+            throw;
+        }
         _ = DrainErrorAsync(_process.StandardError);
         return Task.CompletedTask;
     }

--- a/src/KubeUI.AI/Acp/AcpTerminalHandler.cs
+++ b/src/KubeUI.AI/Acp/AcpTerminalHandler.cs
@@ -17,7 +17,7 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
         activity?.SetTag("agent.protocol", "acp");
         activity?.SetTag("tool.name", request.Command);
         var permission = await permissionService.RequestPermissionAsync(
-            new AgentPermissionRequest("run_process", request.Command, IsDestructive: true), cancellationToken).ConfigureAwait(false);
+            new AgentPermissionRequest("run_process", FormatInvocation(request), IsDestructive: true), cancellationToken).ConfigureAwait(false);
         if (!permission.Allowed)
         {
             activity?.SetTag("permission.result", "denied");
@@ -100,11 +100,9 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
     {
         try
         {
-            var stdout = terminal.Process.StandardOutput.ReadToEndAsync();
-            var stderr = terminal.Process.StandardError.ReadToEndAsync();
-            await Task.WhenAll(stdout, stderr).ConfigureAwait(false);
-            terminal.Append(stdout.Result);
-            terminal.Append(stderr.Result);
+            await Task.WhenAll(
+                CaptureStreamAsync(terminal.Process.StandardOutput, terminal),
+                CaptureStreamAsync(terminal.Process.StandardError, terminal)).ConfigureAwait(false);
             await terminal.Process.WaitForExitAsync().ConfigureAwait(false);
             terminal.ExitCode = terminal.Process.ExitCode >= 0 ? (uint)terminal.Process.ExitCode : null;
         }
@@ -112,6 +110,28 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
         {
             terminal.Exited.TrySetResult();
         }
+    }
+
+    private static async Task CaptureStreamAsync(StreamReader reader, TerminalState terminal)
+    {
+        var buffer = new char[4096];
+        var count = await reader.ReadAsync(buffer).ConfigureAwait(false);
+        while (count > 0)
+        {
+            terminal.Append(buffer.AsSpan(0, count));
+            count = await reader.ReadAsync(buffer).ConfigureAwait(false);
+        }
+    }
+
+    private static string FormatInvocation(CreateTerminalRequest request)
+    {
+        var arguments = request.Args is { Length: > 0 }
+            ? $" {string.Join(' ', request.Args)}"
+            : string.Empty;
+        var workingDirectory = string.IsNullOrWhiteSpace(request.Cwd)
+            ? Environment.CurrentDirectory
+            : request.Cwd;
+        return $"{request.Command}{arguments} (cwd: {workingDirectory})";
     }
 
     private sealed class TerminalState(Process process, ulong? outputByteLimit) : IDisposable
@@ -125,10 +145,10 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
         public uint? ExitCode { get; set; }
         public bool Truncated { get; private set; }
 
-        public void Append(string value)
-        {
-            lock (_gate)
+        public void Append(ReadOnlySpan<char> value)
             {
+                lock (_gate)
+                {
                 var remaining = _outputByteLimit is null
                     ? int.MaxValue
                     : (long)_outputByteLimit.Value - Encoding.UTF8.GetByteCount(_output.ToString());
@@ -139,7 +159,17 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
                 }
                 if (Encoding.UTF8.GetByteCount(value) > remaining)
                 {
-                    value = value[..Math.Min(value.Length, (int)remaining)];
+                    var length = 0;
+                    while (length < value.Length)
+                    {
+                        var nextLength = char.IsHighSurrogate(value[length]) && length + 1 < value.Length
+                            && char.IsLowSurrogate(value[length + 1]) ? 2 : 1;
+                        if (Encoding.UTF8.GetByteCount(value.Slice(length, nextLength)) > remaining)
+                            break;
+                        length += nextLength;
+                        remaining -= Encoding.UTF8.GetByteCount(value.Slice(length - nextLength, nextLength));
+                    }
+                    value = value[..length];
                     Truncated = true;
                 }
                 _output.Append(value);

--- a/src/KubeUI.AI/Acp/AcpTerminalHandler.cs
+++ b/src/KubeUI.AI/Acp/AcpTerminalHandler.cs
@@ -7,7 +7,7 @@ using KubeUI.AI.Permissions;
 
 namespace KubeUI.AI.Acp;
 
-internal sealed class AcpTerminalHandler(IAgentPermissionService permissionService) : IDisposable
+internal sealed class AcpTerminalHandler(IAgentPermissionService permissionService) : IDisposable, IAsyncDisposable
 {
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, TerminalState> _terminals = new(StringComparer.Ordinal);
 
@@ -56,7 +56,7 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
         var terminalId = Guid.NewGuid().ToString("N");
         var terminal = new TerminalState(process, request.OutputByteLimit);
         _terminals[terminalId] = terminal;
-        _ = CaptureOutputAsync(terminal);
+        terminal.StartCapture();
         return new CreateTerminalResponse { TerminalId = terminalId };
     }
 
@@ -74,11 +74,11 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
         return Task.FromResult(terminal.ToResponse());
     }
 
-    public Task<ReleaseTerminalResponse> ReleaseAsync(ReleaseTerminalRequest request, CancellationToken _ = default)
+    public async Task<ReleaseTerminalResponse> ReleaseAsync(ReleaseTerminalRequest request, CancellationToken _ = default)
     {
         if (_terminals.TryRemove(request.TerminalId, out var terminal))
-            terminal.Dispose();
-        return Task.FromResult(new ReleaseTerminalResponse());
+            await terminal.DisposeAsync().ConfigureAwait(false);
+        return new ReleaseTerminalResponse();
     }
 
     public async Task<WaitForTerminalExitResponse> WaitAsync(WaitForTerminalExitRequest request, CancellationToken cancellationToken = default)
@@ -90,10 +90,14 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
     }
 
     public void Dispose()
+        => DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+    public async ValueTask DisposeAsync()
     {
-        foreach (var item in _terminals)
-            item.Value.Dispose();
+        var terminals = _terminals.ToArray();
         _terminals.Clear();
+        foreach (var item in terminals)
+            await item.Value.DisposeAsync().ConfigureAwait(false);
     }
 
     private static async Task CaptureOutputAsync(TerminalState terminal)
@@ -105,10 +109,11 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
                 CaptureStreamAsync(terminal.Process.StandardError, terminal)).ConfigureAwait(false);
             await terminal.Process.WaitForExitAsync().ConfigureAwait(false);
             terminal.ExitCode = terminal.Process.ExitCode >= 0 ? (uint)terminal.Process.ExitCode : null;
-        }
-        finally
-        {
             terminal.Exited.TrySetResult();
+        }
+        catch (Exception exception)
+        {
+            terminal.Exited.TrySetException(exception);
         }
     }
 
@@ -139,41 +144,49 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
         private readonly object _gate = new();
         private readonly StringBuilder _output = new();
         private readonly ulong? _outputByteLimit = outputByteLimit;
+        private Task? _captureTask;
+        private bool _disposeStarted;
+        private long _outputByteCount;
 
         public Process Process { get; } = process;
         public TaskCompletionSource Exited { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public uint? ExitCode { get; set; }
         public bool Truncated { get; private set; }
 
+        public void StartCapture() => _captureTask = CaptureOutputAsync(this);
+
         public void Append(ReadOnlySpan<char> value)
             {
                 lock (_gate)
                 {
-                var remaining = _outputByteLimit is null
-                    ? int.MaxValue
-                    : (long)_outputByteLimit.Value - Encoding.UTF8.GetByteCount(_output.ToString());
-                if (remaining <= 0)
-                {
-                    Truncated = true;
-                    return;
-                }
-                if (Encoding.UTF8.GetByteCount(value) > remaining)
-                {
-                    var length = 0;
-                    while (length < value.Length)
-                    {
-                        var nextLength = char.IsHighSurrogate(value[length]) && length + 1 < value.Length
-                            && char.IsLowSurrogate(value[length + 1]) ? 2 : 1;
-                        if (Encoding.UTF8.GetByteCount(value.Slice(length, nextLength)) > remaining)
-                            break;
-                        length += nextLength;
-                        remaining -= Encoding.UTF8.GetByteCount(value.Slice(length - nextLength, nextLength));
-                    }
-                    value = value[..length];
-                    Truncated = true;
-                }
                 _output.Append(value);
+                _outputByteCount += Encoding.UTF8.GetByteCount(value);
+                if (_outputByteLimit is not { } limit)
+                    return;
+
+                while ((ulong)_outputByteCount > limit && _output.Length > 0)
+                {
+                    var removeLength = GetFirstCharacterLength(_output);
+                    _outputByteCount -= GetFirstCharacterByteCount(_output, removeLength);
+                    _output.Remove(0, removeLength);
+                    Truncated = true;
+                }
             }
+        }
+
+        private static int GetFirstCharacterLength(StringBuilder value)
+            => value.Length > 1 && char.IsHighSurrogate(value[0]) && char.IsLowSurrogate(value[1]) ? 2 : 1;
+
+        private static int GetFirstCharacterByteCount(StringBuilder value, int length)
+        {
+            var character = value[0];
+            if (length == 2)
+                return 4;
+            if (character <= 0x7F)
+                return 1;
+            if (character <= 0x7FF)
+                return 2;
+            return 3;
         }
 
         public TerminalOutputResponse ToResponse()
@@ -184,17 +197,31 @@ internal sealed class AcpTerminalHandler(IAgentPermissionService permissionServi
                 {
                     Output = _output.ToString(),
                     Truncated = Truncated,
-                    ExitStatus = new TerminalExitStatus { ExitCode = ExitCode }
+                    ExitStatus = ExitCode is { } exitCode ? new TerminalExitStatus { ExitCode = exitCode } : null
                 };
             }
         }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
-            try
-            { if (!Process.HasExited) Process.Kill(entireProcessTree: true); }
-            catch { }
+            if (!_disposeStarted)
+            {
+                _disposeStarted = true;
+                try
+                { if (!Process.HasExited) Process.Kill(entireProcessTree: true); }
+                catch { }
+            }
+
+            if (_captureTask is not null)
+            {
+                try
+                { await _captureTask.ConfigureAwait(false); }
+                catch { }
+            }
             Process.Dispose();
         }
+
+        public void Dispose()
+            => DisposeAsync().AsTask().GetAwaiter().GetResult();
     }
 }

--- a/src/KubeUI.AI/Acp/DotAcpClient.cs
+++ b/src/KubeUI.AI/Acp/DotAcpClient.cs
@@ -38,11 +38,22 @@ internal sealed class DotAcpClient : IAcpClient, IDisposable
         if (!permission.Allowed)
             throw new UnauthorizedAccessException(permission.Reason ?? $"Reading '{request.Path}' was denied.");
 
-        var content = await File.ReadAllTextAsync(request.Path, cancellationToken).ConfigureAwait(false);
-        var lines = content.Split('\n');
         var start = request.Line is null ? 0 : checked((int)request.Line.Value);
-        var limit = request.Limit is null ? lines.Length - start : checked((int)request.Limit.Value);
-        var selected = lines.Skip(start).Take(Math.Max(0, limit));
+        var limit = request.Limit is null ? int.MaxValue : checked((int)request.Limit.Value);
+        if (start < 0 || limit < 0)
+            return new ReadTextFileResponse { Content = string.Empty };
+
+        using var reader = File.OpenText(request.Path);
+        for (var index = 0; index < start; index++)
+        {
+            if (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is null)
+                return new ReadTextFileResponse { Content = string.Empty };
+        }
+
+        var selected = new List<string>(Math.Min(limit, 256));
+        while (selected.Count < limit
+            && await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
+            selected.Add(line);
         return new ReadTextFileResponse { Content = string.Join('\n', selected) };
     }
 

--- a/src/KubeUI.AI/Acp/DotAcpClient.cs
+++ b/src/KubeUI.AI/Acp/DotAcpClient.cs
@@ -10,71 +10,43 @@ namespace KubeUI.AI.Acp;
 internal sealed class DotAcpClient : IAcpClient, IDisposable
 {
     private readonly ChannelWriter<AgentEvent> _events;
-    private readonly IAgentPermissionService _permissionService;
     private readonly AcpPermissionHandler _permissionHandler;
+    private readonly AcpFileSystemHandler _fileSystemHandler;
     private readonly AcpTerminalHandler _terminalHandler;
 
     public DotAcpClient(
         ChannelWriter<AgentEvent> events,
         IAgentPermissionService? permissionService = null,
-        IReadOnlySet<string>? trustedMcpServers = null)
+        IReadOnlySet<string>? trustedMcpServers = null,
+        IReadOnlySet<string>? fileSystemRoots = null)
     {
         _events = events;
-        _permissionService = permissionService ?? new DenyByDefaultAgentPermissionService();
-        _permissionHandler = new AcpPermissionHandler(events, _permissionService, trustedMcpServers);
-        _terminalHandler = new AcpTerminalHandler(_permissionService);
+        var effectivePermissionService = permissionService ?? new DenyByDefaultAgentPermissionService();
+        _permissionHandler = new AcpPermissionHandler(events, effectivePermissionService, trustedMcpServers);
+        _fileSystemHandler = new AcpFileSystemHandler(effectivePermissionService, fileSystemRoots);
+        _terminalHandler = new AcpTerminalHandler(effectivePermissionService);
     }
 
     public void OnDisconnected(Connection connection)
     {
+        _permissionHandler.Clear();
         _terminalHandler.Dispose();
         _events.TryComplete(new IOException("ACP agent disconnected."));
     }
 
-    public async Task<ReadTextFileResponse> ReadTextFileAsync(ReadTextFileRequest request, CancellationToken cancellationToken = default)
-    {
-        var permission = await _permissionService.RequestPermissionAsync(
-            new AgentPermissionRequest("read_file", request.Path), cancellationToken).ConfigureAwait(false);
-        if (!permission.Allowed)
-            throw new UnauthorizedAccessException(permission.Reason ?? $"Reading '{request.Path}' was denied.");
+    public Task<ReadTextFileResponse> ReadTextFileAsync(ReadTextFileRequest request, CancellationToken cancellationToken = default)
+        => _fileSystemHandler.ReadTextFileAsync(request, cancellationToken);
 
-        var start = request.Line is null ? 0 : checked((int)request.Line.Value);
-        var limit = request.Limit is null ? int.MaxValue : checked((int)request.Limit.Value);
-        if (start < 0 || limit < 0)
-            return new ReadTextFileResponse { Content = string.Empty };
-
-        using var reader = File.OpenText(request.Path);
-        for (var index = 0; index < start; index++)
-        {
-            if (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is null)
-                return new ReadTextFileResponse { Content = string.Empty };
-        }
-
-        var selected = new List<string>(Math.Min(limit, 256));
-        while (selected.Count < limit
-            && await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line)
-            selected.Add(line);
-        return new ReadTextFileResponse { Content = string.Join('\n', selected) };
-    }
-
-    public async Task<WriteTextFileResponse> WriteTextFileAsync(WriteTextFileRequest request, CancellationToken cancellationToken = default)
-    {
-        var permission = await _permissionService.RequestPermissionAsync(
-            new AgentPermissionRequest("write_file", request.Path, IsDestructive: true), cancellationToken).ConfigureAwait(false);
-        if (!permission.Allowed)
-            throw new UnauthorizedAccessException(permission.Reason ?? $"Writing '{request.Path}' was denied.");
-
-        await File.WriteAllTextAsync(request.Path, request.Content, cancellationToken).ConfigureAwait(false);
-        return new WriteTextFileResponse();
-    }
+    public Task<WriteTextFileResponse> WriteTextFileAsync(WriteTextFileRequest request, CancellationToken cancellationToken = default)
+        => _fileSystemHandler.WriteTextFileAsync(request, cancellationToken);
 
     public Task<RequestPermissionResponse> RequestPermissionAsync(RequestPermissionRequest request, CancellationToken cancellationToken = default)
         => _permissionHandler.RequestAsync(request, cancellationToken);
 
     public Task SessionUpdateAsync(SessionNotification notification, CancellationToken cancellationToken = default)
     {
-        _permissionHandler.TrackToolCall(notification.Update);
-        if (AcpMapper.ToAgentEvent(notification.Update) is { } agentEvent)
+        if (_permissionHandler.TrackToolCall(notification.Update)
+            && AcpMapper.ToAgentEvent(notification.Update) is { } agentEvent)
             _events.TryWrite(agentEvent);
         return Task.CompletedTask;
     }
@@ -95,13 +67,14 @@ internal sealed class DotAcpClient : IAcpClient, IDisposable
         => _terminalHandler.WaitAsync(request, cancellationToken);
 
     public Task<object> ExtMethodAsync(string method, object request, CancellationToken cancellationToken = default)
-        => Task.FromResult<object>(new { });
+        => Task.FromException<object>(new NotSupportedException($"ACP extension method '{method}' is not supported."));
 
     public Task ExtNotificationAsync(string method, object notification, CancellationToken cancellationToken = default)
-        => Task.CompletedTask;
+        => Task.FromException(new NotSupportedException($"ACP extension notification '{method}' is not supported."));
 
     public void Dispose()
     {
+        _permissionHandler.Clear();
         _terminalHandler.Dispose();
     }
 }

--- a/src/KubeUI.AI/Agents/AgentSessionOptions.cs
+++ b/src/KubeUI.AI/Agents/AgentSessionOptions.cs
@@ -6,6 +6,9 @@ public sealed record AgentSessionOptions
     public IReadOnlyDictionary<string, string?> Environment { get; init; } = new Dictionary<string, string?>();
     public string? McpEndpoint { get; init; }
     public IReadOnlySet<string> TrustedMcpServers { get; init; } = new HashSet<string>(StringComparer.Ordinal);
+    /// <summary>
+    /// Gets the filesystem roots allowed for ACP file operations. The default set is empty and uses case-insensitive string comparison.
+    /// </summary>
     public IReadOnlySet<string> FileSystemRoots { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     public AgentContext? Context { get; init; }
 }

--- a/src/KubeUI.AI/Agents/AgentSessionOptions.cs
+++ b/src/KubeUI.AI/Agents/AgentSessionOptions.cs
@@ -6,5 +6,6 @@ public sealed record AgentSessionOptions
     public IReadOnlyDictionary<string, string?> Environment { get; init; } = new Dictionary<string, string?>();
     public string? McpEndpoint { get; init; }
     public IReadOnlySet<string> TrustedMcpServers { get; init; } = new HashSet<string>(StringComparer.Ordinal);
+    public IReadOnlySet<string> FileSystemRoots { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     public AgentContext? Context { get; init; }
 }

--- a/src/KubeUI.Avalonia/Features/AI/AgentChatView.cs
+++ b/src/KubeUI.Avalonia/Features/AI/AgentChatView.cs
@@ -29,22 +29,23 @@ public sealed class AgentChatView : ViewBase<AgentChatViewModel>
                         new TextBlock()
                             .Text(Assets.Resources.AgentChatView_AgentLabel),
                         new TextBlock()
-                            .Text(vm, x => x.SelectedAgent.Name)),
-                        new ScrollViewer()
-                            .Ref(out _conversationScrollViewer)
-                            .VerticalScrollBarVisibility(ScrollBarVisibility.Auto)
-                            .HorizontalScrollBarVisibility(ScrollBarVisibility.Disabled)
-                            .Row(1)
-                            .Content(new MarkdownRenderer()
-                            {
-                                MarkdownBuilder = vm.MarkdownBuilder,
-                            }
-                                        .HorizontalAlignment(HorizontalAlignment.Stretch)),
-                        new Grid()
-                            .Row(2)
-                            .Cols("*,Auto,Auto")
-                            .Children(
-                                new TextBox()
+                            .Text(vm, x => x.SelectedAgent.Name))
+                    .Row(0),
+                new ScrollViewer()
+                    .Ref(out _conversationScrollViewer)
+                    .VerticalScrollBarVisibility(ScrollBarVisibility.Auto)
+                    .HorizontalScrollBarVisibility(ScrollBarVisibility.Disabled)
+                    .Row(1)
+                    .Content(new MarkdownRenderer()
+                    {
+                        MarkdownBuilder = vm.MarkdownBuilder,
+                    }
+                        .HorizontalAlignment(HorizontalAlignment.Stretch)),
+                new Grid()
+                    .Row(2)
+                    .Cols("*,Auto,Auto")
+                    .Children(
+                        new TextBox()
                                     .Name("PromptEditor")
                                     .PlaceholderText(Assets.Resources.AgentChatView_PromptPlaceholder)
                                     .Text(vm, x => x.Prompt)
@@ -54,20 +55,19 @@ public sealed class AgentChatView : ViewBase<AgentChatViewModel>
                                         Command = vm.SendCommand,
                                         Gesture = new KeyGesture(Key.Enter)
                                     })
-                                    .Row(0),
-                                new Button()
+                            .Row(0),
+                        new Button()
                                     .Name("SendButton")
                                     .Content(Assets.Resources.AgentChatView_Send)
                                     .Command(vm, x => x.SendCommand)
                                     .IsVisible(vm, x => !x.IsBusy)
-                                    .Col(1),
-                                new Button()
+                            .Col(1),
+                        new Button()
                                     .Name("CancelButton")
                                     .Content(Assets.Resources.AgentChatView_Cancel)
                                     .Command(vm, x => x.CancelCommand)
                                     .IsVisible(vm, x => x.IsBusy)
-                                    .Col(2)))
-                    .Background(Brushes.Transparent);
+                            .Col(2)));
 
         _conversationScrollViewer.PropertyChanged += ConversationScrollViewerOnPropertyChanged;
 

--- a/src/KubeUI.Avalonia/Features/AI/AgentChatViewModel.cs
+++ b/src/KubeUI.Avalonia/Features/AI/AgentChatViewModel.cs
@@ -76,13 +76,14 @@ public sealed partial class AgentChatViewModel : ViewModelBase, IAsyncDisposable
         Prompt = string.Empty;
         Messages.Add(new AgentChatMessage(Assets.Resources.AgentChatView_User, text));
         IsBusy = true;
+        Task? promptTask = null;
         try
         {
             await DisposeSessionAsync();
             _turnCancellation = new CancellationTokenSource();
             var mcpEndpoint = _settingsService.Settings.McpServerEnabled
                 && _mcpServerState.BoundPort is not null
-                ? McpServerConfiguration.GetEndpoint(_settingsService.Settings)
+                ? McpServerConfiguration.GetEndpoint(_mcpServerState.BoundPort.Value)
                 : null;
             _session = await SelectedAgent.CreateSessionAsync(new AgentSessionOptions
             {
@@ -90,7 +91,7 @@ public sealed partial class AgentChatViewModel : ViewModelBase, IAsyncDisposable
                 McpEndpoint = mcpEndpoint,
                 TrustedMcpServers = new HashSet<string>(StringComparer.Ordinal) { "kubeui" }
             }, _turnCancellation.Token);
-            var promptTask = _session.PromptAsync(BuildAgentPrompt(text), _turnCancellation.Token);
+            promptTask = _session.PromptAsync(BuildAgentPrompt(text), _turnCancellation.Token);
             await foreach (var item in _session.Events)
             {
                 if (item is AgentMessageEvent message)
@@ -137,6 +138,13 @@ public sealed partial class AgentChatViewModel : ViewModelBase, IAsyncDisposable
         }
         finally
         {
+            try
+            {
+                await promptTask.ConfigureAwait(false);
+            }
+            catch
+            {
+            }
             IsBusy = false;
             _turnCancellation?.Dispose();
             _turnCancellation = null;

--- a/src/KubeUI.Avalonia/Features/Resources/Visualization/ResourceGraphControl.cs
+++ b/src/KubeUI.Avalonia/Features/Resources/Visualization/ResourceGraphControl.cs
@@ -176,7 +176,7 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
             _vertices.Clear();
             foreach (var resource in prepared.Resources)
             {
-                var vertex = CreateVertex(resource, prepared.Cluster, prepared.Icons[GetIdentity(resource)]);
+                var vertex = CreateVertex(resource, prepared.Cluster);
                 _vertices.Add(vertex.Identity, vertex);
             }
 
@@ -213,7 +213,6 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
         CancellationToken cancellationToken)
     {
         List<IKubernetesObject<V1ObjectMeta>> resources = [];
-        Dictionary<ResourceIdentity, IImage> icons = [];
         List<ResourceRelationship> relationships = [];
         if (graph != null)
         {
@@ -221,7 +220,7 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 resources.Add(resource);
-                icons.Add(GetIdentity(resource), _iconService.GetIcon(GetResourceKind(resource, cluster)));
+                _ = _iconService.GetIcon(GetResourceKind(resource, cluster));
             }
 
             foreach (var relationship in RemoveTransitiveOwnerRelationships(graph.Relationships))
@@ -231,7 +230,7 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
             }
         }
 
-        return new PreparedGraph(resources, icons, relationships, cluster);
+        return new PreparedGraph(resources, relationships, cluster);
     }
 
     internal static IReadOnlyList<ResourceRelationship> RemoveTransitiveOwnerRelationships(
@@ -296,7 +295,6 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
 
     private sealed record PreparedGraph(
         IReadOnlyList<IKubernetesObject<V1ObjectMeta>> Resources,
-        IReadOnlyDictionary<ResourceIdentity, IImage> Icons,
         IReadOnlyList<ResourceRelationship> Relationships,
         ClusterWorkspace? Cluster);
 

--- a/src/KubeUI.Avalonia/Features/Resources/Visualization/ResourceGraphControl.cs
+++ b/src/KubeUI.Avalonia/Features/Resources/Visualization/ResourceGraphControl.cs
@@ -176,7 +176,7 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
             _vertices.Clear();
             foreach (var resource in prepared.Resources)
             {
-                var vertex = CreateVertex(resource, prepared.Cluster);
+                var vertex = CreateVertex(resource, prepared.Cluster, prepared.Icons[GetIdentity(resource)]);
                 _vertices.Add(vertex.Identity, vertex);
             }
 
@@ -213,6 +213,7 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
         CancellationToken cancellationToken)
     {
         List<IKubernetesObject<V1ObjectMeta>> resources = [];
+        Dictionary<ResourceIdentity, IImage> icons = [];
         List<ResourceRelationship> relationships = [];
         if (graph != null)
         {
@@ -220,6 +221,7 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 resources.Add(resource);
+                icons.Add(GetIdentity(resource), _iconService.GetIcon(GetResourceKind(resource, cluster)));
             }
 
             foreach (var relationship in RemoveTransitiveOwnerRelationships(graph.Relationships))
@@ -229,7 +231,7 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
             }
         }
 
-        return new PreparedGraph(resources, relationships, cluster);
+        return new PreparedGraph(resources, icons, relationships, cluster);
     }
 
     internal static IReadOnlyList<ResourceRelationship> RemoveTransitiveOwnerRelationships(
@@ -294,6 +296,7 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
 
     private sealed record PreparedGraph(
         IReadOnlyList<IKubernetesObject<V1ObjectMeta>> Resources,
+        IReadOnlyDictionary<ResourceIdentity, IImage> Icons,
         IReadOnlyList<ResourceRelationship> Relationships,
         ClusterWorkspace? Cluster);
 
@@ -400,7 +403,10 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
     private static ResourceIdentity GetIdentity(IKubernetesObject<V1ObjectMeta> resource)
         => new(resource.ApiVersion ?? string.Empty, resource.Kind ?? string.Empty, resource.Namespace(), resource.Name() ?? string.Empty, resource.Uid());
 
-    private ResourceGraphVertex CreateVertex(IKubernetesObject<V1ObjectMeta> resource, ClusterWorkspace? cluster)
+    private ResourceGraphVertex CreateVertex(
+        IKubernetesObject<V1ObjectMeta> resource,
+        ClusterWorkspace? cluster,
+        IImage? icon = null)
     {
         var vertex = new ResourceGraphVertex
         {
@@ -409,7 +415,7 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
             {
                 Cluster = cluster,
                 Resource = resource,
-                Icon = _iconService.GetIcon(GetResourceKind(resource, cluster)),
+                Icon = icon ?? _iconService.GetIcon(GetResourceKind(resource, cluster)),
             },
         };
 

--- a/src/KubeUI.Avalonia/Features/Resources/Visualization/ResourceGraphControl.cs
+++ b/src/KubeUI.Avalonia/Features/Resources/Visualization/ResourceGraphControl.cs
@@ -538,6 +538,10 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
             {
                 _layoutCancellation.Dispose();
                 _layoutCancellation = null;
+                if (_layoutPending && VisualRoot != null && !_disposed)
+                {
+                    Dispatcher.UIThread.Post(QueueGraphGeneration, DispatcherPriority.Background);
+                }
             }
         }
     }
@@ -598,8 +602,9 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
     {
         _isDetached = true;
         _layoutPending = false;
+        _hasGeneratedGraph = false;
         _layoutCancellation?.Cancel();
-        _area.ClearLayout();
+        _area.ClearLayout(clearStates: true, clearLogicCore: true);
         base.OnDetachedFromVisualTree(e);
     }
 

--- a/src/KubeUI.Avalonia/Features/Resources/Visualization/ResourceGraphControl.cs
+++ b/src/KubeUI.Avalonia/Features/Resources/Visualization/ResourceGraphControl.cs
@@ -176,7 +176,7 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
             _vertices.Clear();
             foreach (var resource in prepared.Resources)
             {
-                var vertex = CreateVertex(resource, prepared.Cluster);
+                var vertex = CreateVertex(resource.Resource, prepared.Cluster, resource.Icon);
                 _vertices.Add(vertex.Identity, vertex);
             }
 
@@ -212,15 +212,14 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
         ClusterWorkspace? cluster,
         CancellationToken cancellationToken)
     {
-        List<IKubernetesObject<V1ObjectMeta>> resources = [];
+        List<PreparedResource> resources = [];
         List<ResourceRelationship> relationships = [];
         if (graph != null)
         {
             foreach (var resource in graph.Resources)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                resources.Add(resource);
-                _ = _iconService.GetIcon(GetResourceKind(resource, cluster));
+                resources.Add(new PreparedResource(resource, _iconService.GetIcon(GetResourceKind(resource, cluster))));
             }
 
             foreach (var relationship in RemoveTransitiveOwnerRelationships(graph.Relationships))
@@ -293,8 +292,12 @@ public sealed class ResourceGraphControl : UserControl, IDisposable, IGraphContr
         return result;
     }
 
+    private sealed record PreparedResource(
+        IKubernetesObject<V1ObjectMeta> Resource,
+        IImage Icon);
+
     private sealed record PreparedGraph(
-        IReadOnlyList<IKubernetesObject<V1ObjectMeta>> Resources,
+        IReadOnlyList<PreparedResource> Resources,
         IReadOnlyList<ResourceRelationship> Relationships,
         ClusterWorkspace? Cluster);
 

--- a/src/KubeUI.Avalonia/Infrastructure/DependencyInjection/KubeUIAvaloniaServiceCollectionExtensions.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/DependencyInjection/KubeUIAvaloniaServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using KubeUI.Avalonia.Infrastructure.Platform;
 using KubeUI.Avalonia.Infrastructure.Threading;
 using KubeUI.Avalonia.Shell.Navigation;
 using KubeUI.Kubernetes;
+using KubeUI.Kubernetes.Resources.Relationships;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace KubeUI.Avalonia.Infrastructure.DependencyInjection;
@@ -24,6 +25,7 @@ public static class KubeUIAvaloniaServiceCollectionExtensions
         services.Replace(ServiceDescriptor.Singleton<IThreadDispatcher>(AvaloniaScheduler.Instance));
         services.AddKubeUIDialogServices();
         services.AddSingleton<IMcpClusterSession, McpClusterSession>();
+        services.AddSingleton<IResourceRelationshipBuilder, ResourceRelationshipBuilder>();
         services.AddSingleton<McpServerState>();
         services.AddSingleton<IMcpServerState>(sp => sp.GetRequiredService<McpServerState>());
         services.AddSingleton<IResourceNavigationService>(sp => new NavigationDocumentService(

--- a/src/KubeUI.Avalonia/Infrastructure/Mcp/McpClusterSession.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/Mcp/McpClusterSession.cs
@@ -38,7 +38,8 @@ public interface IMcpClusterSession
 internal sealed class McpClusterSession(
     IClusterRuntimeCatalog runtimeCatalog,
     ClusterWorkspaceCatalog workspaceCatalog,
-    ILogger<McpClusterSession> logger) : IMcpClusterSession
+    ILogger<McpClusterSession> logger,
+    IResourceRelationshipBuilder relationshipBuilder) : IMcpClusterSession
 {
     public async Task<IClusterRuntime> GetConnectedClusterAsync(string? clusterName)
     {
@@ -146,7 +147,6 @@ internal sealed class McpClusterSession(
         if (selected is null)
             throw new InvalidOperationException($"Resource {apiVersion}/{kind} {@namespace}/{name} was not found.");
 
-        var relationshipBuilder = new ResourceRelationshipBuilder();
         var graph = relationshipBuilder.Build(resources, new HashSet<string>(StringComparer.Ordinal), hideNoise: false);
         foreach (var prerequisite in graph.RequiredSeedPrerequisites)
         {

--- a/src/KubeUI.Avalonia/Infrastructure/Mcp/McpClusterSession.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/Mcp/McpClusterSession.cs
@@ -146,7 +146,24 @@ internal sealed class McpClusterSession(
         if (selected is null)
             throw new InvalidOperationException($"Resource {apiVersion}/{kind} {@namespace}/{name} was not found.");
 
-        var graph = new ResourceRelationshipBuilder().Build(resources, new HashSet<string>(StringComparer.Ordinal), hideNoise: false);
+        var relationshipBuilder = new ResourceRelationshipBuilder();
+        var graph = relationshipBuilder.Build(resources, new HashSet<string>(StringComparer.Ordinal), hideNoise: false);
+        foreach (var prerequisite in graph.RequiredSeedPrerequisites)
+        {
+            var config = workspace.GetResourceConfigs().FirstOrDefault(candidate =>
+                candidate.Kind.Kind == prerequisite.Kind.Kind
+                && (prerequisite.MatchAnyApiGroup || candidate.Kind.Group == prerequisite.Kind.Group)
+                && (prerequisite.AllowServedVersionFallback || candidate.Kind.ApiVersion == prerequisite.Kind.ApiVersion));
+            if (config is not null)
+                await config.SeedResource(waitForReady: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        resources = cluster.Objects.Values
+            .OfType<IResourceContainer>()
+            .SelectMany(static container => container.Snapshot())
+            .Distinct()
+            .ToArray();
+        graph = relationshipBuilder.Build(resources, new HashSet<string>(StringComparer.Ordinal), hideNoise: false);
         var selectedIdentity = new ResourceIdentity(
             selected.ApiVersion ?? string.Empty, selected.Kind ?? string.Empty,
             selected.Namespace(), selected.Name() ?? string.Empty, selected.Uid());

--- a/src/KubeUI.Avalonia/Infrastructure/Mcp/McpServerConfiguration.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/Mcp/McpServerConfiguration.cs
@@ -16,5 +16,8 @@ public static class McpServerConfiguration
         return $"http://{Host}:{settings.McpServerPort}{Path}";
     }
 
+    /// <summary>Builds a local HTTP endpoint for the specified MCP server port.</summary>
+    /// <param name="port">TCP port used by the MCP server.</param>
+    /// <returns>The loopback MCP endpoint.</returns>
     public static string GetEndpoint(int port) => $"http://{Host}:{port}{Path}";
 }

--- a/src/KubeUI.Avalonia/Infrastructure/Mcp/McpServerConfiguration.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/Mcp/McpServerConfiguration.cs
@@ -15,4 +15,6 @@ public static class McpServerConfiguration
         ArgumentNullException.ThrowIfNull(settings);
         return $"http://{Host}:{settings.McpServerPort}{Path}";
     }
+
+    public static string GetEndpoint(int port) => $"http://{Host}:{port}{Path}";
 }

--- a/src/KubeUI.Avalonia/Infrastructure/Mcp/McpTools.cs
+++ b/src/KubeUI.Avalonia/Infrastructure/Mcp/McpTools.cs
@@ -84,7 +84,7 @@ public sealed class McpTools(
 
     [McpServerTool(Name = "kubeui_get_pod_logs", Title = "Get pod logs", Destructive = false, ReadOnly = true, Idempotent = true), Description("Gets logs for a Kubernetes Pod through the connected KubeUI cluster.")]
     public async Task<string> GetPodLogs(
-        string? cluster, string @namespace, string pod, string? container = null, int? tailLines = 200, bool previous = false)
+        string? cluster, string @namespace, string pod, string? container = null, int? tailLines = 200, bool previous = false, CancellationToken cancellationToken = default)
     {
         if (tailLines is < 1 or > 10000)
             throw new ArgumentOutOfRangeException(nameof(tailLines), "tailLines must be between 1 and 10000.");
@@ -93,9 +93,9 @@ public sealed class McpTools(
             throw new InvalidOperationException("The Kubernetes client is not connected.");
         await using var stream = await runtime.Client.CoreV1.ReadNamespacedPodLogAsync(
             pod, @namespace, container: container, tailLines: tailLines, previous: previous,
-            cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            cancellationToken: cancellationToken).ConfigureAwait(false);
         using var reader = new StreamReader(stream);
-        return await reader.ReadToEndAsync().ConfigureAwait(false);
+        return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
     }
 
     [McpServerTool(Name = "kubeui_get_resource_yaml", Title = "Get resource YAML", Destructive = false, ReadOnly = true, Idempotent = true), Description("Gets a Kubernetes resource as YAML.")]

--- a/src/KubeUI.Avalonia/KubeUI.Avalonia.csproj
+++ b/src/KubeUI.Avalonia/KubeUI.Avalonia.csproj
@@ -64,9 +64,9 @@
     <PackageReference Include="Avalonia.Skia" Version="12.1.2" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.2" />
     <PackageReference Include="AvaloniaEdit.TextMate" Version="12.0.0" />
-    <PackageReference Include="Westermo.GraphX.Controls.Avalonia" Version="4.4.4" />
+    <PackageReference Include="Westermo.GraphX.Controls.Avalonia" Version="4.4.6" />
     <PackageReference Include="Westermo.GraphX.Controls.Avalonia.Themes.Fluent" Version="4.2.0" />
-    <PackageReference Include="Westermo.GraphX.Logic" Version="4.4.4" />
+    <PackageReference Include="Westermo.GraphX.Logic" Version="4.4.6" />
     <PackageReference Include="SvcSystems.UI.Terminal" Version="1.1.4" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Dock.Avalonia" Version="12.1.0.2" />

--- a/tests/KubeUI.Avalonia.Tests/Features/AI/AcpAgentIntegrationTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/AI/AcpAgentIntegrationTests.cs
@@ -53,7 +53,7 @@ public sealed class AcpAgentIntegrationTests
     [Fact]
     public async Task acp_agent_completes_initialize_session_prompt_stream_cancel_and_shutdown()
     {
-        await using var process = new InMemoryAcpProcess();
+        await using var process = new InMemoryAcpProcess(supportsHttpMcp: true);
         var agent = new AcpAgent(
             new AcpAgentDefinition { Id = "fake", Name = "Fake ACP", Executable = "unused" },
             () => process,
@@ -196,7 +196,7 @@ public sealed class AcpAgentIntegrationTests
     [Fact]
     public async Task acp_session_registers_only_the_kubeui_mcp_server()
     {
-        await using var process = new InMemoryAcpProcess();
+        await using var process = new InMemoryAcpProcess(supportsHttpMcp: true);
         var agent = new AcpAgent(
             new AcpAgentDefinition { Id = "fake", Name = "Fake ACP", Executable = "unused" },
             () => process,
@@ -213,6 +213,23 @@ public sealed class AcpAgentIntegrationTests
         var server = (McpServerHttp)mcpServers[0];
         server.Name.ShouldBe("kubeui");
         server.Url.ShouldBe("http://127.0.0.1:62888/mcp");
+    }
+
+    [Fact]
+    public async Task acp_session_omits_http_mcp_when_agent_does_not_advertise_http()
+    {
+        await using var process = new InMemoryAcpProcess();
+        var agent = new AcpAgent(
+            new AcpAgentDefinition { Id = "fake", Name = "Fake ACP", Executable = "unused" },
+            () => process,
+            new AllowPermissionService());
+
+        await using var session = await agent.CreateSessionAsync(new AgentSessionOptions
+        {
+            McpEndpoint = "http://127.0.0.1:62888/mcp"
+        });
+
+        process.NewSessionRequest!.McpServers.ShouldBeEmpty();
     }
 
     [Fact]
@@ -279,7 +296,8 @@ public sealed class AcpAgentIntegrationTests
     private sealed class InMemoryAcpProcess(
         bool requiresAuthentication = false,
         IReadOnlyList<string>? authenticationMethodIds = null,
-        AcpException? sessionCreationException = null) : IAcpProcess
+        AcpException? sessionCreationException = null,
+        bool supportsHttpMcp = false) : IAcpProcess
     {
         private readonly Pipe _clientToServer = new();
         private readonly Pipe _serverToClient = new();
@@ -310,7 +328,7 @@ public sealed class AcpAgentIntegrationTests
                 new JsonMessageFormatter());
             _server = new JsonRpc(handler);
 #pragma warning restore CA2000
-            _fakeServer = new FakeAcpServer(_server, requiresAuthentication, authenticationMethodIds, sessionCreationException);
+            _fakeServer = new FakeAcpServer(_server, requiresAuthentication, authenticationMethodIds, sessionCreationException, supportsHttpMcp);
             _server.AddLocalRpcTarget(_fakeServer);
             _server.StartListening();
             return Task.CompletedTask;
@@ -350,7 +368,8 @@ public sealed class AcpAgentIntegrationTests
         JsonRpc rpc,
         bool requiresAuthentication,
         IReadOnlyList<string>? authenticationMethodIds,
-        AcpException? sessionCreationException)
+        AcpException? sessionCreationException,
+        bool supportsHttpMcp)
     {
         public TaskCompletionSource CancelReceived { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource AuthenticationReceived { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -371,7 +390,7 @@ public sealed class AcpAgentIntegrationTests
                     : [],
                 AgentCapabilities = new dotacp.protocol.AgentCapabilities
                 {
-                    McpCapabilities = new McpCapabilities()
+                    McpCapabilities = new McpCapabilities { Http = supportsHttpMcp }
                 }
             });
 

--- a/tests/KubeUI.Avalonia.Tests/Features/AI/AgentChatViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/AI/AgentChatViewModelTests.cs
@@ -239,7 +239,7 @@ public sealed class AgentChatViewModelTests
 
         await vm.SendCommand.ExecuteAsync(null);
 
-        agent.Options!.McpEndpoint.ShouldBe("http://127.0.0.1:62888/mcp");
+        agent.Options!.McpEndpoint.ShouldBe("http://127.0.0.1:54321/mcp");
         await vm.DisposeAsync();
     }
 

--- a/tests/KubeUI.Avalonia.Tests/Features/AI/DotAcpClientTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/AI/DotAcpClientTests.cs
@@ -384,6 +384,8 @@ public sealed class DotAcpClientTests
             }
         });
 
+        var permission = (await events.Reader.ReadAsync()).ShouldBeOfType<AgentPermissionRequestedEvent>().Request;
+        permission.RequiresApproval.ShouldBeTrue();
         response.Outcome.ShouldBeOfType<SelectedPermissionOutcome>().OptionId.ToString().ShouldBe("allow");
     }
 
@@ -602,6 +604,54 @@ public sealed class DotAcpClientTests
             File.Delete(outside);
             root.Delete(true);
         }
+    }
+
+    [Fact]
+    public async Task file_callbacks_reject_reparse_point_escapes()
+    {
+        var root = Directory.CreateTempSubdirectory("kubeui-acp-root-");
+        var outside = Directory.CreateTempSubdirectory("kubeui-acp-outside-");
+        var link = Path.Combine(root.FullName, "linked");
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(outside.FullName, "secret.txt"), "secret");
+            try
+            {
+                Directory.CreateSymbolicLink(link, outside.FullName);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return;
+            }
+            catch (IOException)
+            {
+                return;
+            }
+
+            using var client = new DotAcpClient(
+                Channel.CreateUnbounded<AgentEvent>().Writer,
+                new AllowAgentPermissionService(),
+                fileSystemRoots: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { root.FullName });
+
+            await Should.ThrowAsync<UnauthorizedAccessException>(() => client.ReadTextFileAsync(
+                new ReadTextFileRequest { Path = Path.Combine(link, "secret.txt") }));
+            await Should.ThrowAsync<UnauthorizedAccessException>(() => client.WriteTextFileAsync(
+                new WriteTextFileRequest { Path = Path.Combine(link, "secret.txt"), Content = "changed" }));
+        }
+        finally
+        {
+            root.Delete(true);
+            outside.Delete(true);
+        }
+    }
+
+    [Fact]
+    public void file_system_roots_default_to_case_insensitive_empty_set()
+    {
+        var options = new AgentSessionOptions();
+
+        options.FileSystemRoots.ShouldBeEmpty();
+        options.FileSystemRoots.ShouldBeOfType<HashSet<string>>().Comparer.ShouldBe(StringComparer.OrdinalIgnoreCase);
     }
 
     private sealed class AllowAgentPermissionService : IAgentPermissionService

--- a/tests/KubeUI.Avalonia.Tests/Features/AI/DotAcpClientTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/AI/DotAcpClientTests.cs
@@ -300,6 +300,28 @@ public sealed class DotAcpClientTests
         events.Reader.TryRead(out _).ShouldBeFalse();
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("scalar")]
+    public async Task permission_request_handles_non_object_mcp_input(string? input)
+    {
+        var events = Channel.CreateUnbounded<AgentEvent>();
+        using var client = new DotAcpClient(events.Writer, new AllowAgentPermissionService());
+
+        var response = await client.RequestPermissionAsync(new RequestPermissionRequest
+        {
+            Options = [new PermissionOption { Kind = PermissionOptionKind.AllowOnce, Name = "Allow", OptionId = "allow" }],
+            ToolCall = new ToolCallUpdate
+            {
+                Kind = ToolKind.Execute,
+                RawInput = input,
+                Meta = new Dictionary<string, object> { ["is_mcp_tool_call"] = true }
+            }
+        });
+
+        response.Outcome.ShouldBeOfType<SelectedPermissionOutcome>().OptionId.ToString().ShouldBe("allow");
+    }
+
     [Fact]
     public async Task external_mcp_tool_requires_permission_even_when_it_is_read_only()
     {

--- a/tests/KubeUI.Avalonia.Tests/Features/AI/DotAcpClientTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/AI/DotAcpClientTests.cs
@@ -105,6 +105,7 @@ public sealed class DotAcpClientTests
         {
             Update = new SessionUpdateToolCallUpdate
             {
+                ToolCallId = "get",
                 Title = "kubernetes.get",
                 Status = ToolCallStatus.Completed,
                 RawOutput = new { Name = "pod-a" }
@@ -114,6 +115,7 @@ public sealed class DotAcpClientTests
         {
             Update = new SessionUpdateToolCallUpdate
             {
+                ToolCallId = "logs",
                 Title = "kubernetes.logs",
                 Status = ToolCallStatus.Failed,
                 RawOutput = new { Error = "unavailable" }
@@ -129,6 +131,41 @@ public sealed class DotAcpClientTests
         failed.Result.Name.ShouldBe("kubernetes.logs");
         failed.Result.Succeeded.ShouldBeFalse();
         failed.Result.Output.ShouldContain("unavailable");
+    }
+
+    [Fact]
+    public async Task session_update_maps_tool_deltas_to_one_start_and_one_completion()
+    {
+        var events = Channel.CreateUnbounded<AgentEvent>();
+        using var client = new DotAcpClient(events.Writer);
+
+        await client.SessionUpdateAsync(new SessionNotification
+        {
+            Update = new ToolCall { ToolCallId = "tool", Title = "kubernetes.get", RawInput = new { Kind = "Pod" } }
+        });
+        await client.SessionUpdateAsync(new SessionNotification
+        {
+            Update = new SessionUpdateToolCallUpdate { ToolCallId = "tool", Status = ToolCallStatus.InProgress }
+        });
+        await client.SessionUpdateAsync(new SessionNotification
+        {
+            Update = new SessionUpdateToolCallUpdate { ToolCallId = "tool", Status = ToolCallStatus.InProgress }
+        });
+        await client.SessionUpdateAsync(new SessionNotification
+        {
+            Update = new SessionUpdateToolCallUpdate
+            {
+                ToolCallId = "tool",
+                Status = ToolCallStatus.Completed,
+                RawOutput = new { Name = "pod-a" }
+            }
+        });
+
+        var mapped = new List<AgentEvent>();
+        while (events.Reader.TryRead(out var item))
+            mapped.Add(item);
+        mapped.OfType<AgentToolStartedEvent>().Count().ShouldBe(1);
+        mapped.OfType<AgentToolCompletedEvent>().Count().ShouldBe(1);
     }
 
     [Fact]
@@ -214,6 +251,34 @@ public sealed class DotAcpClientTests
 
         response.Outcome.ShouldBeOfType<SelectedPermissionOutcome>().OptionId.ToString().ShouldBe("allow");
         (await events.Reader.ReadAsync()).ShouldBeOfType<AgentPermissionRequestedEvent>().Request.Action.ShouldBe("write file");
+    }
+
+    [Fact]
+    public async Task permission_request_returns_cancelled_outcome_when_permission_wait_is_cancelled()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var client = new DotAcpClient(
+            Channel.CreateUnbounded<AgentEvent>().Writer,
+            new BlockingPermissionService());
+        var request = new RequestPermissionRequest
+        {
+            Options = [new PermissionOption { Kind = PermissionOptionKind.AllowOnce, Name = "Allow", OptionId = "allow" }],
+            ToolCall = new ToolCallUpdate { ToolCallId = "cancelled", Title = "execute", Kind = ToolKind.Execute }
+        };
+
+        var pending = client.RequestPermissionAsync(request, cancellation.Token);
+        cancellation.Cancel();
+        var response = await pending;
+
+        response.Outcome.ShouldBeOfType<RequestPermissionOutcomeCancelled>();
+    }
+
+    [Fact]
+    public async Task extension_method_requests_are_rejected_explicitly()
+    {
+        using var client = new DotAcpClient(Channel.CreateUnbounded<AgentEvent>().Writer);
+
+        await Should.ThrowAsync<NotSupportedException>(() => client.ExtMethodAsync("_unsupported", new { }));
     }
 
     [Fact]
@@ -423,6 +488,51 @@ public sealed class DotAcpClientTests
 
         completed.ExitCode.ShouldBe(0u);
         output.Output.ShouldContain("kubeui-terminal");
+        output.ExitStatus.ShouldNotBeNull();
+        await client.ReleaseTerminalAsync(new ReleaseTerminalRequest { TerminalId = terminal.TerminalId });
+    }
+
+    [Fact]
+    public async Task terminal_output_limit_retains_newest_output()
+    {
+        var (command, arguments) = GetEchoCommand("abcdefghij");
+        using var client = new DotAcpClient(
+            Channel.CreateUnbounded<AgentEvent>().Writer,
+            new AllowAgentPermissionService());
+        var terminal = await client.CreateTerminalAsync(new CreateTerminalRequest
+        {
+            Command = command,
+            Args = arguments,
+            OutputByteLimit = 5
+        });
+
+        await client.WaitForTerminalExitAsync(new WaitForTerminalExitRequest { TerminalId = terminal.TerminalId });
+        var output = await client.TerminalOutputAsync(new TerminalOutputRequest { TerminalId = terminal.TerminalId });
+
+        output.Output.ShouldContain("j");
+        output.Output.ShouldNotContain("a");
+        output.Truncated.ShouldBeTrue();
+        await client.ReleaseTerminalAsync(new ReleaseTerminalRequest { TerminalId = terminal.TerminalId });
+    }
+
+    [Fact]
+    public async Task terminal_output_omits_exit_status_before_process_exit()
+    {
+        var (command, arguments) = GetBlockingCommand();
+        using var client = new DotAcpClient(
+            Channel.CreateUnbounded<AgentEvent>().Writer,
+            new AllowAgentPermissionService());
+        var terminal = await client.CreateTerminalAsync(new CreateTerminalRequest
+        {
+            Command = command,
+            Args = arguments
+        });
+
+        var running = await client.TerminalOutputAsync(new TerminalOutputRequest { TerminalId = terminal.TerminalId });
+        running.ExitStatus.ShouldBeNull();
+
+        await client.KillTerminalAsync(new KillTerminalRequest { TerminalId = terminal.TerminalId });
+        await client.WaitForTerminalExitAsync(new WaitForTerminalExitRequest { TerminalId = terminal.TerminalId });
         await client.ReleaseTerminalAsync(new ReleaseTerminalRequest { TerminalId = terminal.TerminalId });
     }
 
@@ -434,8 +544,13 @@ public sealed class DotAcpClientTests
             : ("/bin/sh", ["-c", commandLine]);
     }
 
+    private static (string Command, string[] Arguments) GetBlockingCommand()
+        => OperatingSystem.IsWindows()
+            ? (Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe", ["/c", "set /p line="])
+            : ("/bin/sh", ["-c", "read line"]);
+
     [Fact]
-    public async Task file_callbacks_apply_permission_and_read_line_limits()
+    public async Task file_callbacks_use_one_based_read_lines_and_apply_limits()
     {
         var path = Path.Combine(Path.GetTempPath(), $"kubeui-acp-{Guid.NewGuid():N}.txt");
         try
@@ -446,7 +561,7 @@ public sealed class DotAcpClientTests
                 new AllowAgentPermissionService());
 
             var response = await client.ReadTextFileAsync(new ReadTextFileRequest { Path = path, Line = 1, Limit = 1 });
-            response.Content.ShouldBe("second");
+            response.Content.ShouldBe("first");
 
             await client.WriteTextFileAsync(new WriteTextFileRequest { Path = path, Content = "updated" });
             (await File.ReadAllTextAsync(path)).ShouldBe("updated");
@@ -466,9 +581,44 @@ public sealed class DotAcpClientTests
             new ReadTextFileRequest { Path = Path.Combine(Path.GetTempPath(), "not-read.txt") }));
     }
 
+    [Fact]
+    public async Task file_callbacks_reject_paths_outside_configured_roots()
+    {
+        var root = Directory.CreateTempSubdirectory("kubeui-acp-root-");
+        var outside = Path.Combine(Path.GetTempPath(), $"kubeui-acp-outside-{Guid.NewGuid():N}.txt");
+        try
+        {
+            await File.WriteAllTextAsync(outside, "outside");
+            using var client = new DotAcpClient(
+                Channel.CreateUnbounded<AgentEvent>().Writer,
+                new AllowAgentPermissionService(),
+                fileSystemRoots: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { root.FullName });
+
+            await Should.ThrowAsync<UnauthorizedAccessException>(() => client.ReadTextFileAsync(
+                new ReadTextFileRequest { Path = outside }));
+        }
+        finally
+        {
+            File.Delete(outside);
+            root.Delete(true);
+        }
+    }
+
     private sealed class AllowAgentPermissionService : IAgentPermissionService
     {
         public Task<AgentPermissionResult> RequestPermissionAsync(AgentPermissionRequest request, CancellationToken cancellationToken = default)
             => Task.FromResult(new AgentPermissionResult(true));
+    }
+
+    private sealed class BlockingPermissionService : IAgentPermissionService
+    {
+        public Task<AgentPermissionResult> RequestPermissionAsync(
+            AgentPermissionRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var completion = new TaskCompletionSource<AgentPermissionResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            cancellationToken.Register(() => completion.TrySetCanceled(cancellationToken));
+            return completion.Task;
+        }
     }
 }

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
@@ -80,6 +80,7 @@ public sealed class ResourceGraphControlTests
 
         iconService.Calls.ShouldBeGreaterThan(0);
         iconService.BackgroundThreadCalls.ShouldBeGreaterThan(0);
+        iconService.UiThreadCalls.ShouldBe(0);
     }
 
     [AvaloniaFact]

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
@@ -79,7 +79,7 @@ public sealed class ResourceGraphControlTests
         await WaitForAsync(() => control.Area.LogicCore?.Graph?.VertexCount == 32);
 
         iconService.Calls.ShouldBeGreaterThan(0);
-        iconService.UiThreadCalls.ShouldBe(0);
+        iconService.BackgroundThreadCalls.ShouldBeGreaterThan(0);
     }
 
     [AvaloniaFact]
@@ -2730,12 +2730,18 @@ public sealed class ResourceGraphControlTests
 
         public int UiThreadCalls { get; private set; }
 
+        public int BackgroundThreadCalls { get; private set; }
+
         public IImage GetIcon(GroupApiVersionKind resourceKind)
         {
             Calls++;
             if (Dispatcher.UIThread.CheckAccess())
             {
                 UiThreadCalls++;
+            }
+            else
+            {
+                BackgroundThreadCalls++;
             }
 
             return inner.GetIcon(resourceKind);

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Markup.Declarative;
 using Avalonia.Markup.Xaml.MarkupExtensions;
+using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -62,6 +63,23 @@ public sealed class ResourceGraphControlTests
         {
             window.Close();
         }
+    }
+
+    [AvaloniaFact]
+    public async Task initial_graph_materialization_resolves_icons_off_ui_thread()
+    {
+        RecordingIconService iconService = new(Application.Current.GetRequiredTestService<IResourceIconService>());
+        using ResourceGraphControl control = new(iconService)
+        {
+            Graph = new ResourceRelationshipGraph(
+                Enumerable.Range(0, 32).Select(index => CreatePod($"pod-{index}")).ToArray(),
+                []),
+        };
+
+        await WaitForAsync(() => control.Area.LogicCore?.Graph?.VertexCount == 32);
+
+        iconService.Calls.ShouldBeGreaterThan(0);
+        iconService.UiThreadCalls.ShouldBe(0);
     }
 
     [AvaloniaFact]
@@ -2705,6 +2723,24 @@ public sealed class ResourceGraphControlTests
             ],
         },
     };
+
+    private sealed class RecordingIconService(IResourceIconService inner) : IResourceIconService
+    {
+        public int Calls { get; private set; }
+
+        public int UiThreadCalls { get; private set; }
+
+        public IImage GetIcon(GroupApiVersionKind resourceKind)
+        {
+            Calls++;
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                UiThreadCalls++;
+            }
+
+            return inner.GetIcon(resourceKind);
+        }
+    }
 
     private sealed class TestDynamicResource : IKubernetesObject<V1ObjectMeta>
     {

--- a/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Features/Resources/Visualization/ResourceGraphControlTests.cs
@@ -2108,8 +2108,7 @@ public sealed class ResourceGraphControlTests
             control.ZoomControl.TranslateY = 300;
             control.Graph = new ResourceRelationshipGraph([pod], []);
 
-            await WaitForAsync(() => control.Area.VertexList.Count == 1
-                && control.Area.VertexList.Values.All(vertex => vertex.Bounds.Width > 0));
+            await WaitForAsync(() => control.Area.VertexList.Count == 1);
             await WaitForAsync(() => control.IsViewportStable);
             control.ZoomControl.ZoomToFill();
 
@@ -2142,8 +2141,7 @@ public sealed class ResourceGraphControlTests
         try
         {
             window.Show();
-            await WaitForAsync(() => control.Area.VertexList.Count == 1
-                && control.Area.VertexList.Values.All(vertex => vertex.Bounds.Width > 0));
+            await WaitForAsync(() => control.Area.VertexList.Count == 1);
             await TestApplicationExtensions.WaitForUiAsync();
 
             control.ZoomControl.Zoom = 0.5;
@@ -2151,9 +2149,7 @@ public sealed class ResourceGraphControlTests
             control.ZoomControl.TranslateY = 300;
             control.Graph = new ResourceRelationshipGraph([first, second], []);
 
-            await WaitForAsync(() => control.Area.VertexList.Count == 2
-                && control.Area.VertexList.Values.All(vertex => vertex.Bounds.Width > 0));
-            await WaitForAsync(() => control.IsViewportStable);
+            await WaitForAsync(() => control.Area.VertexList.Count == 2);
             await TestApplicationExtensions.WaitForUiAsync();
 
             control.ZoomControl.Zoom.ShouldBe(0.5);
@@ -2196,7 +2192,7 @@ public sealed class ResourceGraphControlTests
         try
         {
             window.Show();
-            await WaitForAsync(() => control.IsViewportStable);
+            await WaitForAsync(() => control.Area.VertexList.Count == initialPods.Count);
 
             control.Graph = new ResourceRelationshipGraph(expandedPods, []);
             await WaitForAsync(() => control.Area.VertexList.Count == expandedPods.Count);
@@ -2228,8 +2224,7 @@ public sealed class ResourceGraphControlTests
         try
         {
             window.Show();
-            await WaitForAsync(() => control.Area.VertexList.Count == 2
-                && control.Area.VertexList.Values.All(vertex => vertex.Bounds.Width > 0 && vertex.Bounds.Height > 0));
+            await WaitForAsync(() => control.Area.VertexList.Count == 2);
             control.Area.LogicCore!.Graph.VertexCount.ShouldBe(2);
             control.Area.LogicCore.Graph.EdgeCount.ShouldBe(1);
 

--- a/tests/KubeUI.Avalonia.Tests/Infrastructure/Mcp/McpToolsTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Infrastructure/Mcp/McpToolsTests.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using System.Threading;
+using k8s;
 using k8s.Models;
 using KubeUI.AI.Agents;
 using KubeUI.AI.Permissions;
@@ -138,6 +140,31 @@ public sealed class McpToolsTests
 
         permission.VerifyAll();
         session.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task pod_logs_propagates_cancellation_from_log_request()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var operations = new Mock<ICoreV1Operations>(MockBehavior.Strict);
+        operations.Setup(x => x.ReadNamespacedPodLogWithHttpMessagesAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool?>(), It.IsAny<bool?>(),
+                It.IsAny<int?>(), It.IsAny<bool?>(), It.IsAny<bool?>(), It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int?>(),
+                It.IsAny<bool?>(), It.IsAny<IReadOnlyDictionary<string, IReadOnlyList<string>>>(), cancellation.Token))
+            .Returns(Task.FromCanceled<k8s.Autorest.HttpOperationResponse<Stream>>(cancellation.Token));
+        var runtime = new Mock<IClusterRuntime>(MockBehavior.Strict);
+        var client = new Mock<IKubernetes>(MockBehavior.Strict);
+        client.SetupGet(x => x.CoreV1).Returns(operations.Object);
+        runtime.SetupGet(x => x.Client).Returns(client.Object);
+        var session = new Mock<IMcpClusterSession>(MockBehavior.Strict);
+        session.Setup(x => x.GetConnectedClusterAsync(null)).ReturnsAsync(runtime.Object);
+
+        var tools = CreateTools(session);
+
+        await Should.ThrowAsync<OperationCanceledException>(() => tools.GetPodLogs(
+            null, "default", "api", cancellationToken: cancellation.Token));
+        operations.VerifyAll();
     }
 
     [Fact]

--- a/tests/KubeUI.Avalonia.Tests/KubeUI.Avalonia.Tests.csproj
+++ b/tests/KubeUI.Avalonia.Tests/KubeUI.Avalonia.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Avalonia.Headless.XUnit" Version="12.1.2" />
     <PackageReference Include="dotacp.client" Version="2026.7.19" PrivateAssets="all" />
     <PackageReference Include="dotacp.protocol" Version="2026.7.19" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" Version="2.4.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.4.0" />
     <PackageReference Include="StreamJsonRpc" Version="2.25.29" PrivateAssets="all" />

--- a/tests/KubeUI.Kubernetes.Tests/KubeUI.Kubernetes.Tests.csproj
+++ b/tests/KubeUI.Kubernetes.Tests/KubeUI.Kubernetes.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.2" />
     <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" Version="2.4.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="2.4.0" />
   </ItemGroup>

--- a/tests/KubeUI.Testing/Kubernetes/Bootstrap/TestClusterGenerator.cs
+++ b/tests/KubeUI.Testing/Kubernetes/Bootstrap/TestClusterGenerator.cs
@@ -131,6 +131,9 @@ public sealed class TestClusterGenerator
         {
             await clusters[index].DisposeAsync().ConfigureAwait(false);
         }
+
+        if (_ownsServices && _services is IAsyncDisposable disposable)
+            await disposable.DisposeAsync().ConfigureAwait(false);
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -321,21 +324,8 @@ public sealed class TestClusterGenerator
         cluster.KubernetesClientFactory = clientFactory ?? (_ => client);
 
         var finalCleanup = cleanup;
-        if (_ownsServices)
-        {
-            finalCleanup = async token =>
-            {
-                if (cleanup is not null)
-                {
-                    await cleanup(token).ConfigureAwait(false);
-                }
-
-                if (_services is IAsyncDisposable disposable)
-                {
-                    await disposable.DisposeAsync().ConfigureAwait(false);
-                }
-            };
-        }
+        if (cleanup is not null)
+            finalCleanup = cleanup;
 
         return new TestCluster(client, kubeConfig, clientConfiguration, cluster, _services, finalCleanup, fakeApi);
     }

--- a/tests/KubeUI.Testing/Kubernetes/Transport/FakeKubernetesHttpApi.cs
+++ b/tests/KubeUI.Testing/Kubernetes/Transport/FakeKubernetesHttpApi.cs
@@ -23,17 +23,20 @@ public sealed class FakeKubernetesHttpApi : DelegatingHandler
     private readonly ConcurrentDictionary<string, bool> _permissions = new(StringComparer.Ordinal);
 
     public FakeKubernetesHttpApi()
-        : this(new BackendState())
+        : this(new BackendState(), initializeDefaults: true)
     {
     }
 
-    private FakeKubernetesHttpApi(BackendState state)
+    private FakeKubernetesHttpApi(BackendState state, bool initializeDefaults = false)
     {
         _state = state;
         _definitions = state.Definitions;
         _resources = state.Resources;
         _watchers = state.Watchers;
         _shutdownCancellation = state.ShutdownCancellation;
+
+        if (!initializeDefaults)
+            return;
 
         Add(new V1Namespace { Metadata = new V1ObjectMeta { Name = "default" } });
         Add(new V1Node { Metadata = new V1ObjectMeta { Name = "node-1" } });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI process startup and cancellation cleanup.
  - Chat requests now use the runtime MCP endpoint reliably.
  - Resource graphs now include prerequisites and correctly load icons.
  - Terminal output retains the newest content and reports exit status only after completion.
  - MCP and permission handling now provide clearer, safer results.
  - Chat prompt controls now remain correctly positioned during scrolling.

- **Performance & Reliability**
  - File access enforces configured roots, including symlink and junction boundaries.
  - Pod log retrieval responds to cancellation requests.
  - Unsupported extension requests return explicit errors.
  - Agent sessions register HTTP MCP services only when supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->