### PR TITLE
test: add wait for resource list update in PodLogsViewModelTests

### DIFF
--- a/tests/KubeUI.Avalonia.Tests/Resources/Workloads/v1/Pod/PodLogsViewModelTests.cs
+++ b/tests/KubeUI.Avalonia.Tests/Resources/Workloads/v1/Pod/PodLogsViewModelTests.cs
@@ -1018,6 +1018,8 @@ public sealed class PodLogsViewModelTests
                 },
             };
             await workspace.Runtime.AddOrUpdateResource(deployment);
+            await WaitForAsync(() => workspace.Runtime.GetResourceList<V1Deployment>()
+                .Any(item => item.Name() == nextName));
             nextParent = deployment;
         }
         else if (nextName == initialParent.Name())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by waiting for a newly added deployment to become observable before validating its parent-resource identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->